### PR TITLE
Updating to hypre-v2.18.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,7 +710,7 @@ endif()
 ################################
 
 set(HYPRE_DIR "${CMAKE_INSTALL_PREFIX}/hypre")
-set(HYPRE_URL "${TPL_MIRROR_DIR}/hypre-2.15.0.tar.gz")
+set(HYPRE_URL "${TPL_MIRROR_DIR}/hypre-v2.18.2.tar.gz")
 
 message(STATUS "Building HYPRE found at ${HYPRE_URL}")
 

--- a/tplMirror/hypre-2.15.0.tar.gz
+++ b/tplMirror/hypre-2.15.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae1bd6bc9d2d7a97155ec03c46f82a4d0ba4bf88dcf73122a1b909bef300d3b9
-size 7351813

--- a/tplMirror/hypre-v2.18.2.tar.gz
+++ b/tplMirror/hypre-v2.18.2.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28007b5b584eaf9397f933032d8367788707a2d356d78e47b99e551ab10cc76a
+size 5699792


### PR DESCRIPTION
This pr update _hypre_ to version v2.18.2 (latest) in the TPL suite.