### PR TITLE
Remove Fortran from PETSc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -868,6 +868,8 @@ file(WRITE ${PROJECT_BINARY_DIR}/config_petsc_for_geosx "\
 --CFLAGS=\"${PETSC_C_FLAGS}\" \
 --CXX=${PETSC_CXX_COMPILER} \
 --CXXFLAGS=\"${PETSC_CXX_FLAGS}\" \
+--FC=${PETSC_Fortran_COMPILER} \
+--FFLAGS=\"${PETSC_Fortran_FLAGS}\" \
 --with-fortran-bindings=0 \
 --with-metis-dir=${CMAKE_INSTALL_PREFIX}/metis \
 --with-64-bit-indices=1 \


### PR DESCRIPTION
Currently, we compile `PETSc` with an option producing Fortran modules, but we're not using them at all ... it's a waste of time and space!