### PR TITLE
Patch chai's umpire

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,7 +372,8 @@ ExternalProject_Add( chai
                      PREFIX ${PROJECT_BINARY_DIR}/chai
                      URL ${CHAI_URL}
                      INSTALL_DIR ${CHAI_DIR}
-                     PATCH_COMMAND patch -p1 < ${TPL_MIRROR_DIR}/Umpire-b78dd50.patch
+                     PATCH_COMMAND patch -p1 < ${TPL_MIRROR_DIR}/Umpire-b78dd50.patch &&
+                                   patch -p0 < ${TPL_MIRROR_DIR}/Umpire-gcc.patch
                      DEPENDS raja
                      BUILD_COMMAND ${TPL_BUILD_COMMAND}
                      INSTALL_COMMAND ${TPL_INSTALL_COMMAND}

--- a/tplMirror/Umpire-gcc.patch
+++ b/tplMirror/Umpire-gcc.patch
@@ -1,0 +1,13 @@
+--- src/tpl/umpire/src/umpire/resource/CudaConstantMemoryResource.cu	2019-09-16 15:34:51.000000000 -0700
++++ src/tpl/umpire/src/umpire/resource/FixedCudaConstantMemoryResource.cu	2020-03-06 13:51:44.759965000 -0800
+@@ -32,8 +32,8 @@
+   m_highwatermark{0},
+   m_platform{Platform::cuda},
+   m_offset{0},
+-  m_initialized{false},
+-  m_ptr{nullptr}
++  m_ptr{nullptr},
++  m_initialized{false}
+ {
+ }
+ 


### PR DESCRIPTION
Patches chai's umpire to get rid of initializer list error when building with gcc.
Extracted from GEOSX/thirdPartyLibs#101