### PR TITLE
Re-enable VTK build in OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ geosx_osx_build: &geosx_osx_build
   - git lfs pull
   script:
   - GEOSX_TPL_DIR=/usr/local/GEOSX/GEOSX_TPL && sudo mkdir -p -m a=rwx ${GEOSX_TPL_DIR}/..
-  - python scripts/config-build.py -hc ${TRAVIS_BUILD_DIR}/host-configs/darwin-clang.cmake -bt Release -ip ${GEOSX_TPL_DIR} -DNUM_PROC=$(nproc) -DGEOSXTPL_ENABLE_DOXYGEN:BOOL=OFF -DENABLE_VTK:BOOL=OFF
+  - python scripts/config-build.py -hc ${TRAVIS_BUILD_DIR}/host-configs/darwin-clang.cmake -bt Release -ip ${GEOSX_TPL_DIR} -DNUM_PROC=$(nproc) -DGEOSXTPL_ENABLE_DOXYGEN:BOOL=OFF
   - cd build-darwin-clang-release
   - make
   # The deployment phase is done here because the `deploy` stage of travis does not work for PR.


### PR DESCRIPTION
This PR re-enables VTK build in Travis OSX VM.

Currently it will fail due to the build halting around 2h30m mark during random TPL builds, despite Travis job limit being 3h. We can use this PR to figure out a workaround.