### PR TITLE
Changed to hypre mgr-block-jacobi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -725,7 +725,7 @@ endif()
 
 if( ENABLE_HYPRE )
   set( HYPRE_DIR "${CMAKE_INSTALL_PREFIX}/hypre" )
-  set( HYPRE_URL "${TPL_MIRROR_DIR}/hypre-04af9a4cd9f4548a619e1b7dd5763cd5512a2588.zip")
+  set( HYPRE_URL "${TPL_MIRROR_DIR}/hypre-918265d184711861fee0ba9a19b3bb9c1defd98d.zip")
   
 
   message(STATUS "Building HYPRE found at ${HYPRE_URL}")

--- a/tplMirror/hypre-04af9a4cd9f4548a619e1b7dd5763cd5512a2588.zip
+++ b/tplMirror/hypre-04af9a4cd9f4548a619e1b7dd5763cd5512a2588.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aee9062bb5eb04a879d765b1f361c440ae05518d881e13d5976847f3446d55f8
-size 7256401

--- a/tplMirror/hypre-918265d184711861fee0ba9a19b3bb9c1defd98d.zip
+++ b/tplMirror/hypre-918265d184711861fee0ba9a19b3bb9c1defd98d.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:356eb8af9f9fbbcf0a26e5632117eec585b94da7672782d6b1cff6eed5cf95ed
+size 230903958


### PR DESCRIPTION
For deployment on Pangea II, because users need an iterative linear solver