### PR TITLE
fix boolean comparison

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.23.1)
 project(geosx_tpl LANGUAGES C CXX Fortran)
 
 option( GEOSXTPL_ENABLE_DOXYGEN "" ON )
-if ( ENABLE_DOXYGEN EQUAL OFF )
+if ( ENABLE_DOXYGEN )
     set( GEOSXTPL_ENABLE_DOXYGEN "OFF" )
 endif()
 set( ENABLE_DOXYGEN OFF CACHE BOOL "" FORCE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_minimum_required(VERSION 3.23.1)
 project(geosx_tpl LANGUAGES C CXX Fortran)
 
 option( GEOSXTPL_ENABLE_DOXYGEN "" ON )
-if ( ENABLE_DOXYGEN )
+if ( NOT ENABLE_DOXYGEN )
     set( GEOSXTPL_ENABLE_DOXYGEN "OFF" )
 endif()
 set( ENABLE_DOXYGEN OFF CACHE BOOL "" FORCE )


### PR DESCRIPTION
`CMake` [supports additional constants](https://cmake.org/cmake/help/latest/command/if.html#basic-expressions) other than `ON / OFF` in if clauses.

Using a hardcoded constant is a mistake.
