### PR TITLE
changing path for automated deployment in Sherlock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ jobs:
     - DOCKERFILE=docker/Stanford/Dockerfile
     - DOCKER_ROOT_IMAGE=jafranc/sherlock-gcc10.1.0-openmpi4.1.2-cuda11.5.0-openblas0.3.10-zlib1.2.11-no-geosx:0.0.1
     - HOST_CONFIG=docker/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10.cmake
-    - INSTALL_DIR=/home/groups/tchelepi/geosx-sherlock/CPU/GEOSX_TPL-${TRAVIS_PULL_REQUEST}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:7}
+    - INSTALL_DIR=/oak/stanford/schools/ees/COLLABORATIONS/geosx/CPU/GEOSX_TPL-${TRAVIS_PULL_REQUEST}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:7}
   - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, cuda 11.5.0, openblas 0.3.10, zlib 1.2.11)
     <<: *geosx_linux_build
     env:
@@ -100,7 +100,7 @@ jobs:
     - DOCKERFILE=docker/Stanford/Dockerfile
     - DOCKER_ROOT_IMAGE=jafranc/sherlock-gcc10.1.0-openmpi4.1.2-cuda11.5.0-openblas0.3.10-zlib1.2.11-no-geosx:0.0.1
     - HOST_CONFIG=docker/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10-cuda11.5.0-sm80.cmake
-    - INSTALL_DIR=/home/groups/tchelepi/geosx-sherlock/GPU/GEOSX_TPL-${TRAVIS_PULL_REQUEST}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:7}
+    - INSTALL_DIR=/oak/stanford/schools/ees/COLLABORATIONS/geosx/GPU/GEOSX_TPL-${TRAVIS_PULL_REQUEST}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:7}
   - name: Mac OSX
     <<: *geosx_osx_build
   - name: Ubuntu (20.04, gcc 9.3.0, open-mpi 4.0.3)


### PR DESCRIPTION
Changing path for automated deployment in Sherlock from formerly `/home/groups/tchelepi/geosx-sherlock` to `/oak/stanford/schools/ees/COLLABORATIONS/geosx` for it to be accessible to people in Stanford outside of `tchelepi` group.