### PR TITLE
Fix wrong setting of CMAKE_VERBOSE_MAKEFILE variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ message( "Running with NUM_PROC = ${NUM_PROC}")
 set(TPL_MIRROR_DIR "${CMAKE_SOURCE_DIR}/tplMirror")
 set(build_list )
 
-set( CMAKE_VERBOSE_MAKEFILE BOOL OFF "" )
+set( CMAKE_VERBOSE_MAKEFILE OFF "" )
 
 # Set up C flags
 string(REPLACE "-Wall" "" C_FLAGS_NO_WARNINGS ${CMAKE_C_FLAGS})


### PR DESCRIPTION
The CMAKE_VERBOSE_MAKEFILE variable was setted to `BOOL;OFF;` due to an erroneous call of the SET function of CMake (for non cache variable, the type of the variable is not expected).

It was leading to the following warning when compiling some of the TPLs (for example adiak with `VERBOSE=1 make` command):
```
CMake Warning:
  Ignoring extra path from command line:

   "/Users/froehly/GEOS-FORK/thirdPartyLibs-AlgianeFork/build-appleM1-clang-debug/adiak/src/adiak-build/OFF"
```
