### PR TITLE
Build hdf5 using CMake instead of Autogen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1288,14 +1288,10 @@ if( ENABLE_FESAPI )
                                     -DWITH_PYTHON_WRAPPING:BOOL=OFF
                                     -DWITH_RESQML2_2:BOOL=OFF
                                     -DWITH_TEST:BOOL=OFF
-                                    # Next lines prevent compilation
-                                    # errors due to an issue with the
-                                    # detection of the hdf5 version in
-                                    # fesapi < 2.4.0.0 (on CentOS, for
-                                    # Release build of hdf5, see
-                                    # https://github.com/F2I-Consulting/fesapi/issues/326)
-                                    # It should be possible to remove it when
-                                    # fesapi-2.9.0.0 will be released
+                                    # Next lines prevent compilation errors due to an issue
+                                    # with the detection of the hdf5 version in fesapi < 2.4.0.0
+                                    # (on CentOS, for Release build of hdf5, see https://github.com/F2I-Consulting/fesapi/issues/326)
+                                    # It should be possible to remove it when fesapi-2.9.0.0 will be released
                                     -DWITH_LOCAL_HDF5:BOOL=ON
                                     -DHDF5_INCLUDE_DIRS:PATH=${HDF5_DIR}/include
                                     -DHDF5_LIBRARIES:PATH=${HDF5_DIR}/lib/libhdf5${CMAKE_SHARED_LIBRARY_SUFFIX}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,29 +186,35 @@ message(STATUS "Building HDF5 found at ${HDF5_URL}")
 if( ${ENABLE_MPI} )
   set( HDF5_C_COMPILER ${MPI_C_COMPILER} )
   set( HDF5_CXX_COMPILER ${MPI_CXX_COMPILER} )
-  set( HDF5_ENABLE_PARALLEL "--enable-parallel")
 else()
   set( HDF5_C_COMPILER ${CMAKE_C_COMPILER} )
   set( HDF5_CXX_COMPILER ${CMAKE_CXX_COMPILER} )
-  set( HDF5_ENABLE_PARALLEL "")
 endif()
-
-set(HDF5_C_FLAGS "-fPIC ${C_FLAGS_NO_WARNINGS} ${CMAKE_C_FLAGS_RELEASE}")
 
 ExternalProject_Add( hdf5
                      URL ${HDF5_URL}
                      PREFIX ${PROJECT_BINARY_DIR}/hdf5
                      INSTALL_DIR ${HDF5_DIR}
-                     CONFIGURE_COMMAND ../hdf5/configure
-                                       CC=${HDF5_C_COMPILER}
-                                       CXX=${HDF5_CXX_COMPILER}
-                                       --enable-build-mode=production
-                                       --prefix=<INSTALL_DIR>
-                                       ${HDF5_ENABLE_PARALLEL}
-                                       --enable-shared=yes
-                                       CFLAGS=${HDF5_C_FLAGS}
                      BUILD_COMMAND make -j ${NUM_PROC}
-                     INSTALL_COMMAND make install )
+                     INSTALL_COMMAND make install
+                     CMAKE_ARGS -D CMAKE_C_COMPILER:STRING=${HDF5_C_COMPILER}
+                                -D CMAKE_CXX_COMPILER:STRING=${HDF5_CXX_COMPILER}
+                                -D CMAKE_C_FLAGS:STRING=${C_FLAGS_NO_WARNINGS}
+                                -D CMAKE_C_FLAGS_RELEASE:STRING=${CMAKE_C_FLAGS_RELEASE}
+                                -D CMAKE_CXX_FLAGS:STRING=${CXX_FLAGS_NO_WARNINGS}
+                                -D CMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
+                                -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+                                -D CMAKE_VERBOSE_MAKEFILE:BOOL=${CMAKE_VERBOSE_MAKEFILE}
+                                -D HDF5_ENABLE_PARALLEL:BOOL=${ENABLE_MPI}
+                                -D CMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
+                                -D CMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+                                -D BUILD_SHARED_LIBS:BOOL=ON
+                                -D BUILD_STATIC_LIBS:BOOL=OFF
+                                -D BUILD_TESTING:BOOL=OFF
+                                -D HDF5_BUILD_EXAMPLES:BOOL=OFF
+                                -D HDF5_BUILD_TOOLS:BOOL=OFF
+                                -D HDF5_BUILD_UTILS:BOOL=OFF
+                                )
 
 list(APPEND HDF5_DEPENDENCIES hdf5 )
 list(APPEND build_list hdf5 )
@@ -1080,7 +1086,7 @@ if( ENABLE_VTK )
 
     message( STATUS "Building VTK found at ${VTK_URL}" )
 
-    # Depending on the platfor, the install directory could be 'lib' or 'lib64'.
+    # Depending on the platform, the install directory could be 'lib' or 'lib64'.
     # This makes the 'rpath' task more complicated to deal with a single script ('CMAKE_INSTALL_RPATH' option).
     # Defining explicitly 'lib' deals with this issue.
     # I'm no cmake expert and I do not know if there was a better way to deal with it.
@@ -1247,7 +1253,7 @@ if( ENABLE_FESAPI )
                                     -DCMAKE_C_COMPILER=${FESAPI_C_COMPILER}
                                     -DCMAKE_CXX_COMPILER=${FESAPI_CXX_COMPILER}
                                     -DCMAKE_CXX_FLAGS=${TPL_CXX_STANDARD}
-                                    -DHDF5_ROOT:PATH=${HDF5_DIR}
+                                    -DCMAKE_PREFIX_PATH:PATH=${HDF5_DIR}
                                     -DMINIZIP_INCLUDE_DIR:PATH=${MINIZIP_DIR}/include
                                     -DMINIZIP_LIBRARY_RELEASE:PATH=${MINIZIP_DIR}/lib/libminizip.a
                                     -DBoost_NO_SYSTEM_PATHS:BOOL=TRUE
@@ -1258,7 +1264,19 @@ if( ENABLE_FESAPI )
                                     -DWITH_JAVA_WRAPPING:BOOL=OFF
                                     -DWITH_PYTHON_WRAPPING:BOOL=OFF
                                     -DWITH_RESQML2_2:BOOL=OFF
-                                    -DWITH_TEST:BOOL=OFF)
+                                    -DWITH_TEST:BOOL=OFF
+                                    # Next lines prevent compilation
+                                    # errors due to an issue with the
+                                    # detection of the hdf5 version in
+                                    # fesapi < 2.4.0.0 (on CentOS, for
+                                    # Release build of hdf5, see
+                                    # https://github.com/F2I-Consulting/fesapi/issues/326)
+                                    # It should be possible to remove it when
+                                    # fesapi-2.9.0.0 will be released
+                                    -DWITH_LOCAL_HDF5:BOOL=ON
+                                    -DHDF5_INCLUDE_DIRS:PATH=${HDF5_DIR}/include
+                                    -DHDF5_LIBRARIES:PATH=${HDF5_DIR}/lib/libhdf5${CMAKE_SHARED_MODULE_SUFFIX}
+                                  )
 
     list(APPEND build_list fesapi )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,16 @@ else()
   set( HDF5_CXX_COMPILER ${CMAKE_CXX_COMPILER} )
 endif()
 
+# Build hdf5 in RelWithDebInfo mode to avoid errors when compiling
+# Silo: Silo's autogen script fails to find the hdf5 library if it is
+# built in Debug mode with CMake due to hdf5 naming convention (see
+# https://github.com/LLNL/Silo/issues/369).
+if( CMAKE_BUILD_TYPE MATCHES Debug )
+  set( HDF5_CMAKE_BUILD_TYPE RelWithDebInfo )
+else()
+  set( HDF5_CMAKE_BUILD_TYPE CMAKE_BUILD_TYPE )
+endif()
+
 ExternalProject_Add( hdf5
                      URL ${HDF5_URL}
                      PREFIX ${PROJECT_BINARY_DIR}/hdf5
@@ -203,7 +213,7 @@ ExternalProject_Add( hdf5
                                 -D CMAKE_C_FLAGS_RELEASE:STRING=${CMAKE_C_FLAGS_RELEASE}
                                 -D CMAKE_CXX_FLAGS:STRING=${CXX_FLAGS_NO_WARNINGS}
                                 -D CMAKE_CXX_FLAGS_RELEASE:STRING=${CMAKE_CXX_FLAGS_RELEASE}
-                                -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+                                -D CMAKE_BUILD_TYPE:STRING=${HDF5_CMAKE_BUILD_TYPE}
                                 -D CMAKE_VERBOSE_MAKEFILE:BOOL=${CMAKE_VERBOSE_MAKEFILE}
                                 -D HDF5_ENABLE_PARALLEL:BOOL=${ENABLE_MPI}
                                 -D CMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ message(STATUS "Building SILO found at ${SILO_URL}")
 # using autogen.
 #
 if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
-  # HDF5_C_FLAGS is used only here so we can overwritting it
+  # HDF5_C_FLAGS is used only here so we can overwrite it
   LIST( APPEND HDF5_C_FLAGS -w )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,8 @@ ExternalProject_Add( silo
                      DEPENDS ${HDF5_DEPENDENCIES}
                      CONFIGURE_COMMAND ../silo/configure
                                           CC=${HDF5_C_COMPILER}
-                                          CFLAGS=${HDF5_C_FLAGS}
+                                          # Ensure that silo is built with position independent code
+                                          "CFLAGS=${HDF5_C_FLAGS} -fpic"
                                           CXX=${HDF5_CXX_COMPILER}
                                           --prefix=<INSTALL_DIR>
                                           --disable-fortran

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,19 @@ set(SILO_DIR "${CMAKE_INSTALL_PREFIX}/silo")
 set(SILO_URL "${TPL_MIRROR_DIR}/silo-4.11-bsd.tgz")
 message(STATUS "Building SILO found at ${SILO_URL}")
 
+# -w compiler flag is needed to build Silo release 4.11 with
+# AppleClang or regular Clang due to implicit declaration of
+# 'zfp_init_zfp'. This issue is fixed by release 4.11.1 so it will be
+# possible to remove the `-w` flag when we will use this latter (see
+# https://github.com/LLNL/Silo/issues/224).
+#
+# This -w flag was exported inside the HDF5_C_FLAGS variable when hdf5 was built
+# using autogen.
+#
+if( CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
+  # HDF5_C_FLAGS is used only here so we can overwritting it
+  LIST( APPEND HDF5_C_FLAGS -w )
+endif()
 
 ExternalProject_Add( silo
                      URL ${SILO_URL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1275,7 +1275,7 @@ if( ENABLE_FESAPI )
                                     # fesapi-2.9.0.0 will be released
                                     -DWITH_LOCAL_HDF5:BOOL=ON
                                     -DHDF5_INCLUDE_DIRS:PATH=${HDF5_DIR}/include
-                                    -DHDF5_LIBRARIES:PATH=${HDF5_DIR}/lib/libhdf5${CMAKE_SHARED_MODULE_SUFFIX}
+                                    -DHDF5_LIBRARIES:PATH=${HDF5_DIR}/lib/libhdf5${CMAKE_SHARED_LIBRARY_SUFFIX}
                                   )
 
     list(APPEND build_list fesapi )


### PR DESCRIPTION
This PR avoids the spurious detection of the `NDEBUG` compilation flag by `CMake` when importing the `hdf5` package.

As a side-effect, it will allow to test the `GEOS` asserts in github-ci configs running in `Debug` mode.

See:
  - `GEOS` issue https://github.com/GEOS-DEV/GEOS/issues/2631
  - `hdf5` issue https://github.com/HDFGroup/hdf5/issues/3526#issuecomment-1719664682

I initially proposed this PR from a fork of the `TPL`s but the ci fail due to missing authorization to connect to DockerHub.
Previous discussion is available in the [initial PR](https://github.com/GEOS-DEV/thirdPartyLibs/pull/239).

Reverts GEOS-DEV/thirdPartyLibs#247 which was reverting https://github.com/GEOS-DEV/thirdPartyLibs/pull/243

closes https://github.com/GEOS-DEV/GEOS/issues/2631
Relates to https://github.com/GEOS-DEV/GEOS/pull/2721/