### PR TITLE
Upgrade `sccache` to 0.7.2

### DIFF
--- a/docker/Stanford/Dockerfile
+++ b/docker/Stanford/Dockerfile
@@ -48,5 +48,5 @@ RUN yum -y install \
 RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja
 
 RUN mkdir -p /opt/sccache/bin && \
-    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
+    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.7.2/sccache-v0.7.2-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
 ENV SCCACHE=/opt/sccache/bin/sccache

--- a/docker/TotalEnergies/Dockerfile
+++ b/docker/TotalEnergies/Dockerfile
@@ -48,5 +48,5 @@ RUN yum -y install \
 RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja
 
 RUN mkdir -p /opt/sccache/bin && \
-    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
+    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.7.2/sccache-v0.7.2-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
 ENV SCCACHE=/opt/sccache/bin/sccache

--- a/docker/clang-cuda/Dockerfile
+++ b/docker/clang-cuda/Dockerfile
@@ -86,5 +86,5 @@ RUN apt-get install -y --no-install-recommends \
     ninja-build
 
 RUN mkdir -p /opt/sccache/bin && \
-    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
+    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.7.2/sccache-v0.7.2-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
 ENV SCCACHE=/opt/sccache/bin/sccache

--- a/docker/gcc-cuda/Dockerfile
+++ b/docker/gcc-cuda/Dockerfile
@@ -89,5 +89,5 @@ RUN yum install -y \
 RUN curl -fsSL https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip | zcat > /usr/local/bin/ninja && chmod +x /usr/local/bin/ninja
 
 RUN mkdir -p /opt/sccache/bin && \
-    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
+    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.7.2/sccache-v0.7.2-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf -
 ENV SCCACHE=/opt/sccache/bin/sccache

--- a/docker/gcc-ubuntu/Dockerfile
+++ b/docker/gcc-ubuntu/Dockerfile
@@ -125,7 +125,7 @@ RUN apt-get install -y --no-install-recommends \
 # Install `sccache` binaries to speed up the build of `geos`.
 RUN apt-get install -y --no-install-recommends curl && \
     mkdir -p /opt/sccache/bin && \
-    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.5.4/sccache-v0.5.4-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf - && \
+    curl -fsSL https://github.com/mozilla/sccache/releases/download/v0.7.2/sccache-v0.7.2-x86_64-unknown-linux-musl.tar.gz | tar --directory=/opt/sccache/bin --strip-components=1 -xzf - && \
     apt-get purge --auto-remove -y curl
 # This environment variable is meant to be used instead of an hard-coded path.
 ENV SCCACHE=/opt/sccache/bin/sccache


### PR DESCRIPTION
Support for `nvcc` was improved with version 0.6. Let's try it!