### PR TITLE
Script for building LC TPLs with Uberenv

### DIFF
--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+## Builds the TPLs for a specific system and host config.
+## Usage ./setupLC-TPL-uberenv-helper.bash pathToGeosxDirectory pathToInstallDirectory machine compiler commandToGetANode [extra arguments to config-build ]
+#GEOSX_DIR=$1
+GEOS_BRANCH=$1
+INSTALL_DIR=$2
+MACHINE=$3
+COMPILER=$4
+SPEC=$5
+GET_A_NODE=$6
+
+## Eat up the command line arguments so the rest can be forwarded to config-build.
+shift
+shift
+shift
+shift
+shift
+
+CONFIG=$MACHINE-$COMPILER
+LOG_FILE=$CONFIG.log
+HOST_CONFIG=$GEOSX_DIR/host-configs/LLNL/$CONFIG.cmake
+INSTALL_DIR=$INSTALL_DIR/install-$CONFIG-release
+
+#echo "Building the TPLs on $MACHINE for $HOST_CONFIG to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
+echo "Building the TPLs on $MACHINE for $COMPILER to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
+
+ssh $MACHINE -t "
+. /etc/profile  &&
+cd tempGEOS &&
+$GET_A_NODE ./scripts/uberenv/uberenv.py --spec=$SPEC --prefix $INSTALL_DIR $@ &&
+exit" > $LOG_FILE 2>&1
+
+# ssh $MACHINE -t "
+# . /etc/profile  &&
+# cd $PWD &&
+# module load cmake/3.23.1 &&
+# python3 scripts/config-build.py -hc $HOST_CONFIG -bt Release -ip $INSTALL_DIR $@ &&
+# cd build-$CONFIG-release &&
+# $GET_A_NODE make &&
+# exit" > $LOG_FILE 2>&1
+
+## Check the last three lines of the log file. A BLT smoke test should be the last
+## thing built and should show up on one of the final lines.
+tail -3 $LOG_FILE | grep -E "\[100%\] Built target blt_.*_smoke" > /dev/null
+if [ $? -eq 0 ]; then
+    chmod g+rx -R $INSTALL_DIR
+    chgrp GEOS -R $INSTALL_DIR
+    echo "Build of $HOST_CONFIG completed successfully."
+    exit 0
+else
+    echo "Build of $HOST_CONFIG seemed to fail, check $LOG_FILE."
+    exit 1
+fi

--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -20,15 +20,17 @@ shift
 CONFIG=$MACHINE-$COMPILER
 LOG_FILE=$CONFIG.log
 HOST_CONFIG=$GEOSX_DIR/host-configs/LLNL/$CONFIG.cmake
-INSTALL_DIR=$INSTALL_DIR/install-$CONFIG-release
+#INSTALL_DIR=$INSTALL_DIR/install-$CONFIG-release
 
 #echo "Building the TPLs on $MACHINE for $HOST_CONFIG to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
 echo "Building the TPLs on $MACHINE for $COMPILER to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
 
 ssh $MACHINE -t "
 . /etc/profile  &&
-cd tempGEOS &&
-$GET_A_NODE ./scripts/uberenv/uberenv.py --spec=$SPEC --prefix $INSTALL_DIR $@ &&
+cd $PWD/tempGEOS &&
+echo $SPEC &&
+echo $GET_A_NODE &&
+$GET_A_NODE ./scripts/uberenv/uberenv.py --spec=$SPEC --prefix $INSTALL_DIR &&
 exit" > $LOG_FILE 2>&1
 
 # ssh $MACHINE -t "

--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -1,14 +1,12 @@
 #!/bin/bash
 
 ## Builds the TPLs for a specific system and host config.
-## Usage ./setupLC-TPL-uberenv-helper.bash pathToGeosxDirectory pathToInstallDirectory machine compiler commandToGetANode
-#GEOSX_DIR=$1
-GEOS_BRANCH=$1
-INSTALL_DIR=$2
-MACHINE=$3
-COMPILER=$4
-SPEC=\"${5}\"
-GET_A_NODE=$6
+## Usage ./setupLC-TPL-uberenv-helper.bash pathToInstallDirectory machine compiler spackSpecToBuild commandToGetANode
+INSTALL_DIR=$1
+MACHINE=$2
+COMPILER=$3
+SPEC=\"${4}\"
+GET_A_NODE=$5
 
 ## Eat up the command line arguments so the rest can be forwarded to config-build.
 shift
@@ -19,30 +17,14 @@ shift
 
 CONFIG=$MACHINE-$COMPILER
 LOG_FILE=$CONFIG.log
-# HOST_CONFIG=$GEOSX_DIR/host-configs/LLNL/$CONFIG.cmake
-#INSTALL_DIR=$INSTALL_DIR/install-$CONFIG-release
 
-#echo "Building the TPLs on $MACHINE for $HOST_CONFIG to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
 echo "Building the TPLs on $MACHINE for $COMPILER to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
 
 ssh $MACHINE -t "
 . /etc/profile  &&
 cd $PWD/tempGEOS &&
-echo $SPEC &&
-echo $GET_A_NODE &&
 $GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix ${INSTALL_DIR}/${CONFIG}_tpls --spack-env-name ${CONFIG}_env &&
 exit" > $LOG_FILE 2>&1
-
-# $GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix $INSTALL_DIR --spack-env-name ${CONFIG}_env --skip-setup &&
-
-# ssh $MACHINE -t "
-# . /etc/profile  &&
-# cd $PWD &&
-# module load cmake/3.23.1 &&
-# python3 scripts/config-build.py -hc $HOST_CONFIG -bt Release -ip $INSTALL_DIR $@ &&
-# cd build-$CONFIG-release &&
-# $GET_A_NODE make &&
-# exit" > $LOG_FILE 2>&1
 
 ## Check the last ten lines of the log file.
 ## A successful install should show up on one of the final lines.

--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## Builds the TPLs for a specific system and host config.
-## Usage ./setupLC-TPL-uberenv-helper.bash pathToGeosxDirectory pathToInstallDirectory machine compiler commandToGetANode [extra arguments to config-build ]
+## Usage ./setupLC-TPL-uberenv-helper.bash pathToGeosxDirectory pathToInstallDirectory machine compiler commandToGetANode
 #GEOSX_DIR=$1
 GEOS_BRANCH=$1
 INSTALL_DIR=$2
@@ -30,8 +30,10 @@ ssh $MACHINE -t "
 cd $PWD/tempGEOS &&
 echo $SPEC &&
 echo $GET_A_NODE &&
-$GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix $INSTALL_DIR --spack-env-name ${CONFIG}_env --skip-setup &&
+$GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix ${INSTALL_DIR}/${CONFIG}_tpls --spack-env-name ${CONFIG}_env &&
 exit" > $LOG_FILE 2>&1
+
+# $GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix $INSTALL_DIR --spack-env-name ${CONFIG}_env --skip-setup &&
 
 # ssh $MACHINE -t "
 # . /etc/profile  &&
@@ -48,9 +50,9 @@ tail -10 $LOG_FILE | grep -E "Successfully installed geos" > /dev/null
 if [ $? -eq 0 ]; then
     chmod g+rx -R $INSTALL_DIR
     chgrp GEOS -R $INSTALL_DIR
-    echo "Build of $HOST_CONFIG completed successfully."
+    echo "Build of ${CONFIG} completed successfully."
     exit 0
 else
-    echo "Build of $HOST_CONFIG seemed to fail, check $LOG_FILE."
+    echo "Build of ${CONFIG} seemed to fail, check $LOG_FILE."
     exit 1
 fi

--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -7,7 +7,7 @@ GEOS_BRANCH=$1
 INSTALL_DIR=$2
 MACHINE=$3
 COMPILER=$4
-SPEC=$5
+SPEC=\"${5}\"
 GET_A_NODE=$6
 
 ## Eat up the command line arguments so the rest can be forwarded to config-build.
@@ -19,7 +19,7 @@ shift
 
 CONFIG=$MACHINE-$COMPILER
 LOG_FILE=$CONFIG.log
-HOST_CONFIG=$GEOSX_DIR/host-configs/LLNL/$CONFIG.cmake
+# HOST_CONFIG=$GEOSX_DIR/host-configs/LLNL/$CONFIG.cmake
 #INSTALL_DIR=$INSTALL_DIR/install-$CONFIG-release
 
 #echo "Building the TPLs on $MACHINE for $HOST_CONFIG to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
@@ -30,7 +30,7 @@ ssh $MACHINE -t "
 cd $PWD/tempGEOS &&
 echo $SPEC &&
 echo $GET_A_NODE &&
-$GET_A_NODE ./scripts/uberenv/uberenv.py --spec=$SPEC --prefix $INSTALL_DIR &&
+$GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix $INSTALL_DIR --spack-env-name ${CONFIG}_env --skip-setup &&
 exit" > $LOG_FILE 2>&1
 
 # ssh $MACHINE -t "

--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -42,9 +42,9 @@ exit" > $LOG_FILE 2>&1
 # $GET_A_NODE make &&
 # exit" > $LOG_FILE 2>&1
 
-## Check the last three lines of the log file. A BLT smoke test should be the last
-## thing built and should show up on one of the final lines.
-tail -3 $LOG_FILE | grep -E "\[100%\] Built target blt_.*_smoke" > /dev/null
+## Check the last ten lines of the log file.
+## A successful install should show up on one of the final lines.
+tail -10 $LOG_FILE | grep -E "Successfully installed geos" > /dev/null
 if [ $? -eq 0 ]; then
     chmod g+rx -R $INSTALL_DIR
     chgrp GEOS -R $INSTALL_DIR

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+## Builds the TPLs on all LC systems. Must be run from the top level TPL directory.
+## Usage ./setupLC-TPL.bash branchToBuild pathToInstallDirectory [extra arguments to config-build ]
+GEOS_BRANCH=$1
+INSTALL_DIR=$2
+
+## Eat up the command line arguments so the rest can be forwarded to setupLC-TPL-helper.
+shift
+shift
+
+## Trap the interupt signal and kill all children.
+trap 'killall' INT
+
+killall() {
+    trap '' INT TERM     # ignore INT and TERM while shutting down
+    echo "**** Shutting down. Killing chid processes ****"     # added double quotes
+    kill -TERM 0         # fixed order, send TERM not INT
+    wait
+    echo DONE
+}
+
+# Check if branch exists
+branch_exists=$(git ls-remote https://github.com/GEOS-DEV/GEOS.git $GEOS_BRANCH | wc -l)
+
+if [[ $branch_exists != 1 ]] ; then
+    echo "Branch $GEOS_BRANCH does not exist in GEOS repository"
+    exit
+fi
+
+if [[ -z $INSTALL_DIR ]]; then
+    echo "No installation directory path was provided"
+    exit
+fi
+
+if [[ ! -d $INSTALL_DIR ]]; then
+  echo "Installation directory $INSTALL_DIR does not exist. Please initialize first."
+  exit
+fi
+
+if [[ ! "$INSTALL_DIR" = /* ]]; then
+  echo "Installation directory $INSTALL_DIR must be an absolute path."
+  exit
+fi
+
+# Clone GEOS repo to build with uberenv
+echo "Cloning branch $GEOS_BRANCH in temporary GEOS repo directory tempGEOS to build TPLs with uberenv..."
+rm -rf tempGEOS
+git clone -b $GEOS_BRANCH https://github.com/GEOS-DEV/GEOS.git tempGEOS
+
+cd tempGEOS
+git submodule init scripts/uberenv
+git submodule init src/cmake/blt
+git submodule init src/coreComponents/LvArray
+git submodule update
+cd ..
+
+echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR"
+chmod -R g+rx $INSTALL_DIR
+chgrp -R GEOS $INSTALL_DIR
+# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
+# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
+# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70" "lalloc 1 -W 150" $@ &
+
+wait
+echo "Removing temporary GEOS repo tempGEOS..."
+rm -rf tempGEOS
+
+echo "Complete"
+

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -58,11 +58,12 @@ cd ..
 echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR"
 chmod -R g+rx $INSTALL_DIR
 chgrp -R GEOS $INSTALL_DIR
-# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
-# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
-# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
-# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
-# ./scripts/setupLC-TPL-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70" "lalloc 1 -W 150" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR rzgenie clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
+# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
+# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
+# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70" "lalloc 1 -W 150" $@ &
 
 wait
 echo "Removing temporary GEOS repo tempGEOS..."

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -51,17 +51,17 @@ git clone -b $GEOS_BRANCH https://github.com/GEOS-DEV/GEOS.git tempGEOS
 cd tempGEOS
 git submodule init scripts/uberenv
 git submodule update
-./scripts/uberenv/uberenv.py --prefix $INSTALL_DIR --setup-only --spack-env-file scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
+# ./scripts/uberenv/uberenv.py --prefix $INSTALL_DIR --setup-only --spack-env-file scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
 cd ..
 
 echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR"
 chmod -R g+rx $INSTALL_DIR
 chgrp -R GEOS $INSTALL_DIR
-#./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "salloc -N 1 -t 150 -n 1 " $@ &
-# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
-# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "salloc -N 1 -t 150 " $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "salloc -N 1 -t 150 " $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
-# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 
 wait
 

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -50,23 +50,26 @@ git clone -b $GEOS_BRANCH https://github.com/GEOS-DEV/GEOS.git tempGEOS
 
 cd tempGEOS
 git submodule init scripts/uberenv
-git submodule init src/cmake/blt
-git submodule init src/coreComponents/LvArray
 git submodule update
+./scripts/uberenv/uberenv.py --prefix $INSTALL_DIR --setup-only --spack-env-file scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
 cd ..
 
 echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR"
 chmod -R g+rx $INSTALL_DIR
 chgrp -R GEOS $INSTALL_DIR
- ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
+#./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "salloc -N 1 -t 150 -n 1 " $@ &
 # ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
 # ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
-# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
-# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70" "lalloc 1 -W 150" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 
 wait
-echo "Removing temporary GEOS repo tempGEOS..."
-rm -rf tempGEOS
+
+echo "Copying generated host-configs..."
+cd tempGEOS && cp *.cmake ..
+
+#echo "Removing temporary GEOS repo tempGEOS..."
+#rm -rf tempGEOS
 
 echo "Complete"
 

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -58,8 +58,7 @@ cd ..
 echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR"
 chmod -R g+rx $INSTALL_DIR
 chgrp -R GEOS $INSTALL_DIR
-./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR rzgenie clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
-# ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
+ ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
 # ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "srun -N 1 -t 150 -n 1 -A geosecp" $@ &
 # ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 # ./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## Builds the TPLs on all LC systems. Must be run from the top level TPL directory.
-## Usage ./setupLC-TPL.bash branchToBuild pathToInstallDirectory [extra arguments to config-build ]
+## Usage ./setupLC-TPL.bash branchToBuild pathToInstallDirectory
 GEOS_BRANCH=$1
 INSTALL_DIR=$2
 
@@ -24,13 +24,13 @@ killall() {
 branch_exists=$(git ls-remote https://github.com/GEOS-DEV/GEOS.git $GEOS_BRANCH | wc -l)
 
 if [[ $branch_exists != 1 ]] ; then
-    echo "Branch $GEOS_BRANCH does not exist in GEOS repository"
-    exit
+  echo "Branch $GEOS_BRANCH does not exist in GEOS repository"
+  exit
 fi
 
 if [[ -z $INSTALL_DIR ]]; then
-    echo "No installation directory path was provided"
-    exit
+  echo "No installation directory path was provided"
+  exit
 fi
 
 if [[ ! -d $INSTALL_DIR ]]; then
@@ -51,25 +51,26 @@ git clone -b $GEOS_BRANCH https://github.com/GEOS-DEV/GEOS.git tempGEOS
 cd tempGEOS
 git submodule init scripts/uberenv
 git submodule update
-# ./scripts/uberenv/uberenv.py --prefix $INSTALL_DIR --setup-only --spack-env-file scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
 cd ..
 
-echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR"
+echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR..."
 chmod -R g+rx $INSTALL_DIR
 chgrp -R GEOS $INSTALL_DIR
-./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "salloc -N 1 -t 150 " $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "salloc -N 1 -t 150 " $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $GEOS_BRANCH $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR quartz clang-14 "%clang@14.0.6 +docs" "salloc -N 1 -t 150 " $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR quartz gcc-12 "%gcc@12.1.1 +docs" "salloc -N 1 -t 150 " $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen clang-10-cuda-11 "%clang@10.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 
+# Note: Estimated completion time is ~90 minutes.
+# Check log files for unreported completion of jobs.
 wait
 
-echo "Copying generated host-configs..."
+echo "Copying generated host-configs from tempGEOS directory..."
 cd tempGEOS && cp *.cmake ..
 
-#echo "Removing temporary GEOS repo tempGEOS..."
-#rm -rf tempGEOS
+echo "Removing temporary GEOS repo tempGEOS..."
+rm -rf tempGEOS
 
 echo "Complete"
 


### PR DESCRIPTION
This PR adds a `setupLC-TPL-uberenv.bash` script to build third-party libraries on quartz and lassen using uberenv.

Script temporarily clones a GEOS branch and uses the branch's spack environment files and uberenv submodule to launch uberenv jobs on quartz and lassen for each compiler.
A host-config is generated for each system-compiler pair at the end of the uberenv run.

Related to GEOS-DEV/GEOS#2028