### PR TITLE
Add Pangea4 host configs

### DIFF
--- a/host-configs/TOTAL/pangea4-base.cmake
+++ b/host-configs/TOTAL/pangea4-base.cmake
@@ -1,0 +1,66 @@
+#######################################
+#
+# Pangea4 - base config for CPU cluster
+#
+#   - RAJA   CPU
+#   - CHAI   CPU
+#   - CUDA   OFF
+#   - OPENMP OFF
+#
+#######################################
+
+#######################################
+# SCIENTIFIC LIBRARIES
+#######################################
+
+# build all TPLs scientifc libs and let GEOS build choose which one to use
+
+set( ENABLE_FESAPI      ON CACHE BOOL "" FORCE )
+set( ENABLE_HYPRE       ON CACHE BOOL "" FORCE )
+set( ENABLE_MATHPRESSO  ON CACHE BOOL "" FORCE )
+set( ENABLE_PAMELA      ON CACHE BOOL "" FORCE )
+set( ENABLE_PETSC       ON CACHE BOOL "" FORCE )
+set( ENABLE_PVTPackage  ON CACHE BOOL "" FORCE )
+set( ENABLE_SCOTCH      ON CACHE BOOL "" FORCE )
+set( ENABLE_SUITESPARSE ON CACHE BOOL "" FORCE )
+set( ENABLE_TRILINOS    ON CACHE BOOL "" FORCE )
+set( ENABLE_VTK         ON CACHE BOOL "" FORCE )
+
+#######################################
+# DEVLOPMENT TOOLS
+#######################################
+
+set( ENABLE_DOXYGEN           ON CACHE BOOL "" FORCE )
+set( ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "" FORCE )
+set( ENABLE_UNCRUSTIFY        ON CACHE BOOL "" FORCE )
+set( ENABLE_XML_UPDATES       ON CACHE BOOL "" FORCE )
+
+#######################################
+# PERFORMANCE TOOLS
+#######################################
+
+set( ENABLE_BENCHMARKS ON CACHE BOOL "" FORCE )
+set( ENABLE_CALIPER    ON CACHE BOOL "" FORCE )
+
+#######################################
+# RAJA/CHAI/OPENMP SETUP
+#######################################
+
+set( ENABLE_OPENMP      OFF         CACHE PATH "" FORCE )
+set( ENABLE_CUDA        OFF         CACHE PATH "" FORCE )
+
+set( ENABLE_CHAI        ON          CACHE PATH "" FORCE )
+set( CHAI_BUILD_TYPE    "cpu-no-rm" CACHE PATH "" FORCE )
+set( CHAI_ARGS          ""          CACHE PATH "" FORCE )
+
+set( ENABLE_RAJA        ON          CACHE PATH "" FORCE )
+set( RAJA_ENABLE_HIP    OFF         CACHE PATH "" FORCE )
+set( RAJA_ENABLE_OPENMP OFF         CACHE PATH "" FORCE )
+set( RAJA_ENABLE_TBB    OFF         CACHE PATH "" FORCE )
+
+#######################################
+# PYTHON SETUP
+#######################################
+
+set( ENABLE_PYGEOSX         ON CACHE BOOL "" )
+set( ENABLE_VTK_WRAP_PYTHON ON CACHE BOOL "" )

--- a/host-configs/TOTAL/pangea4-base.cmake
+++ b/host-configs/TOTAL/pangea4-base.cmake
@@ -13,7 +13,7 @@
 # SCIENTIFIC LIBRARIES
 #######################################
 
-# build all TPLs scientifc libs and let GEOS build choose which one to use
+# build all TPLs scientific libs and let GEOS build choose which one to use
 
 set( ENABLE_FESAPI      ON CACHE BOOL "" FORCE )
 set( ENABLE_HYPRE       ON CACHE BOOL "" FORCE )
@@ -27,7 +27,7 @@ set( ENABLE_TRILINOS    ON CACHE BOOL "" FORCE )
 set( ENABLE_VTK         ON CACHE BOOL "" FORCE )
 
 #######################################
-# DEVLOPMENT TOOLS
+# DEVELOPMENT TOOLS
 #######################################
 
 set( ENABLE_DOXYGEN           ON CACHE BOOL "" FORCE )

--- a/host-configs/TOTAL/pangea4-base.cmake
+++ b/host-configs/TOTAL/pangea4-base.cmake
@@ -32,6 +32,7 @@ set( ENABLE_VTK         ON CACHE BOOL "" FORCE )
 
 set( ENABLE_DOXYGEN           ON CACHE BOOL "" FORCE )
 set( ENABLE_GTEST_DEATH_TESTS ON CACHE BOOL "" FORCE )
+set( ENABLE_SPHINX            ON CACHE BOOL "" FORCE )
 set( ENABLE_UNCRUSTIFY        ON CACHE BOOL "" FORCE )
 set( ENABLE_XML_UPDATES       ON CACHE BOOL "" FORCE )
 
@@ -43,7 +44,7 @@ set( ENABLE_BENCHMARKS ON CACHE BOOL "" FORCE )
 set( ENABLE_CALIPER    ON CACHE BOOL "" FORCE )
 
 #######################################
-# RAJA/CHAI/OPENMP SETUP
+# RAJA/CHAI SETUP
 #######################################
 
 set( ENABLE_OPENMP      OFF         CACHE PATH "" FORCE )

--- a/host-configs/TOTAL/pangea4-base.cmake
+++ b/host-configs/TOTAL/pangea4-base.cmake
@@ -46,17 +46,17 @@ set( ENABLE_CALIPER    ON CACHE BOOL "" FORCE )
 # RAJA/CHAI SETUP
 #######################################
 
-set( ENABLE_OPENMP      OFF         CACHE PATH "" FORCE )
-set( ENABLE_CUDA        OFF         CACHE PATH "" FORCE )
+set( ENABLE_OPENMP      OFF         CACHE BOOL "" FORCE )
+set( ENABLE_CUDA        OFF         CACHE BOOL "" FORCE )
 
-set( ENABLE_CHAI        ON          CACHE PATH "" FORCE )
-set( CHAI_BUILD_TYPE    "cpu-no-rm" CACHE PATH "" FORCE )
-set( CHAI_ARGS          ""          CACHE PATH "" FORCE )
+set( ENABLE_CHAI        ON          CACHE BOOL   "" FORCE )
+set( CHAI_BUILD_TYPE    "cpu-no-rm" CACHE STRING "" FORCE )
+set( CHAI_ARGS          ""          CACHE STRING "" FORCE )
 
-set( ENABLE_RAJA        ON          CACHE PATH "" FORCE )
-set( RAJA_ENABLE_HIP    OFF         CACHE PATH "" FORCE )
-set( RAJA_ENABLE_OPENMP OFF         CACHE PATH "" FORCE )
-set( RAJA_ENABLE_TBB    OFF         CACHE PATH "" FORCE )
+set( ENABLE_RAJA        ON          CACHE BOOL "" FORCE )
+set( RAJA_ENABLE_HIP    OFF         CACHE BOOL "" FORCE )
+set( RAJA_ENABLE_OPENMP OFF         CACHE BOOL "" FORCE )
+set( RAJA_ENABLE_TBB    OFF         CACHE BOOL "" FORCE )
 
 #######################################
 # PYTHON SETUP

--- a/host-configs/TOTAL/pangea4-base.cmake
+++ b/host-configs/TOTAL/pangea4-base.cmake
@@ -15,7 +15,6 @@
 
 # build all TPLs scientific libs and let GEOS build choose which one to use
 
-set( ENABLE_FESAPI      ON CACHE BOOL "" FORCE )
 set( ENABLE_HYPRE       ON CACHE BOOL "" FORCE )
 set( ENABLE_MATHPRESSO  ON CACHE BOOL "" FORCE )
 set( ENABLE_PAMELA      ON CACHE BOOL "" FORCE )
@@ -63,5 +62,4 @@ set( RAJA_ENABLE_TBB    OFF         CACHE PATH "" FORCE )
 # PYTHON SETUP
 #######################################
 
-set( ENABLE_PYGEOSX         ON CACHE BOOL "" )
 set( ENABLE_VTK_WRAP_PYTHON ON CACHE BOOL "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
@@ -53,7 +53,7 @@ set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
 set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                )
+set( DEBUG_FLAGS   "-00 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
@@ -1,0 +1,95 @@
+#######################################
+#
+# Pangea4 - gcc - hpcxompi - onemkl
+#
+# Uses :
+#   - cray wrappers for gcc (cc, CC, ftn)
+#   - oneAPI MKL    for BLAS and LAPACK
+#   - HPC-X OpenMPI for MPI
+#
+#######################################
+#
+# Requires modules :
+#   - PrgEnv-gnu           = 8.4.0, which loads :
+#     . gcc                = 12.1
+#     . craype             = 2.7.23
+#     . cray-dsmml         = 0.2.2
+#     . craype-network-ofi = 1.0
+#     . libfabric          = 1.13.1
+#   - cmake                = 3.27.2
+#   - cray-python          = 3.10.10
+#   - craype-x86-milan     = 1.0
+#     PrgEnv-gnu loads gcc 12 that does not support craype-x86-genoa
+#   - hpcx-ompi            = 2.17.1
+#   - intel-oneapi-mkl     = 2023.2.0
+#
+# Load modules this way :
+#   - module purge
+#   - module load PrgEnv-gnu/8.4.0 craype-x86-milan cmake/3.27.2 cray-python/3.10.10
+#   - module unload cray-libsci/23.09.1.1 cray-mpich/8.1.27
+#   - module load hpcx-ompi intel-oneapi-mkl/2023.2.0
+#
+########################################
+
+set( CONFIG_NAME "pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0" CACHE PATH "" )
+
+include(${CMAKE_CURRENT_LIST_DIR}/pangea4-base.cmake)
+
+#######################################
+# COMPILER SETUP
+#######################################
+
+# use :
+#  - cray wrappers for gnu compilers so that we link properly with infiniband network
+#  - explicit optimization flags even when using cray wrappers
+
+if( NOT DEFINED ENV{GCC_PATH} )
+    message( FATAL_ERROR "GCC_PATH is not defined. Please load the PrgEnv-gnu/8.4.0 module." )
+endif()
+
+set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
+set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
+set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
+
+set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
+set( RELEASE_FLAGS "-DNDEBUG"                        )
+
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+
+#######################################
+# MPI SETUP
+#######################################
+
+# use :
+# - HPC-X OpenMPI library
+
+set( ENABLE_MPI ON CACHE BOOL "" )
+
+if( NOT DEFINED ENV{HPCX_MPI_DIR} )
+    message( FATAL_ERROR "HPC-X OpenMPI is not loaded. Please load the hpcx-ompi module." )
+endif()
+
+#######################################                                                                                                                                           
+# BLAS/LAPACK SETUP                                                                                                                                                               
+#######################################
+
+# use :
+# - intel oneAPI MKL library
+
+set( ENABLE_MKL ON CACHE BOOL "" FORCE )
+
+if( NOT DEFINED ENV{MKLROOT} )
+    message( FATAL_ERROR "MKL is not loaded. Please load the intel-oneapi-mkl/2023.2.0 module." )
+endif()
+
+set( MKL_INCLUDE_DIRS $ENV{MKLROOT}/include CACHE STRING "" )
+set( MKL_LIBRARIES    $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
+                      $ENV{MKLROOT}/lib/intel64/libmkl_gnu_thread.so
+                      $ENV{MKLROOT}/lib/intel64/libmkl_core.so
+                      $ENV{GCC_PATH}/lib/gcc/x86_64-redhat-linux/12/libgomp.so
+                      CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
@@ -44,7 +44,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/pangea4-base.cmake)
 #  - explicit optimization flags even when using cray wrappers
 
 if( NOT DEFINED ENV{GCC_PATH} )
-    message( FATAL_ERROR "GCC_PATH is not defined. Please load the PrgEnv-gnu/8.4.0 module." )
+    message( FATAL_ERROR "GCC is not loaded. Please load the PrgEnv-gnu/8.4.0 module." )
 endif()
 
 set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
@@ -88,8 +88,6 @@ if( NOT DEFINED ENV{MKLROOT} )
 endif()
 
 set( MKL_INCLUDE_DIRS $ENV{MKLROOT}/include CACHE STRING "" )
-set( MKL_LIBRARIES    $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
-                      $ENV{MKLROOT}/lib/intel64/libmkl_gnu_thread.so
-                      $ENV{MKLROOT}/lib/intel64/libmkl_core.so
+set( MKL_LIBRARIES    $ENV{MKLROOT}/lib/intel64/libmkl_rt.so
                       $ENV{GCC_PATH}/lib/gcc/x86_64-redhat-linux/12/libgomp.so
                       CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
@@ -52,8 +52,8 @@ set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
-set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                      )
+set( RELEASE_FLAGS "-O3 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-O0 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
@@ -51,15 +51,19 @@ set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
 set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
-set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
-set( RELEASE_FLAGS "-DNDEBUG"                        )
+set( COMMON_FLAGS  "-march=native -mtune=native" )
+set( RELEASE_FLAGS "-03 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-00 -g"                )
 
-set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_DEBUG       ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_C_FLAGS_DEBUG         ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_DEBUG   ${DEBUG_FLAGS}   CACHE STRING "" )
 
 #######################################
 # MPI SETUP

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0.cmake
@@ -20,14 +20,14 @@
 #   - cray-python          = 3.10.10
 #   - craype-x86-milan     = 1.0
 #     PrgEnv-gnu loads gcc 12 that does not support craype-x86-genoa
-#   - hpcx-ompi            = 2.17.1
+#   - hpcx                 = 2.17.1
 #   - intel-oneapi-mkl     = 2023.2.0
 #
 # Load modules this way :
 #   - module purge
 #   - module load PrgEnv-gnu/8.4.0 craype-x86-milan cmake/3.27.2 cray-python/3.10.10
 #   - module unload cray-libsci/23.09.1.1 cray-mpich/8.1.27
-#   - module load hpcx-ompi intel-oneapi-mkl/2023.2.0
+#   - module load hpcx intel-oneapi-mkl/2023.2.0
 #
 ########################################
 
@@ -71,7 +71,7 @@ set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
 set( ENABLE_MPI ON CACHE BOOL "" )
 
 if( NOT DEFINED ENV{HPCX_MPI_DIR} )
-    message( FATAL_ERROR "HPC-X OpenMPI is not loaded. Please load the hpcx-ompi module." )
+    message( FATAL_ERROR "HPC-X OpenMPI is not loaded. Please load the hpcx module." )
 endif()
 
 #######################################                                                                                                                                           

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
@@ -20,14 +20,14 @@
 #   - cray-python          = 3.10.10
 #   - craype-x86-milan     = 1.0
 #     PrgEnv-gnu loads gcc 12 that does not support craype-x86-genoa
-#   - hpcx-ompi            = 2.17.1
+#   - hpcx                 = 2.17.1
 #   - openblas             = 0.3.23
 #
 # Load modules this way :
 #   - module purge
 #   - module load PrgEnv-gnu/8.4.0 craype-x86-milan cmake/3.27.2 cray-python/3.10.10
 #   - module unload cray-libsci/23.09.1.1 cray-mpich/8.1.27
-#   - module load hpcx-ompi openblas/0.3.23
+#   - module load hpcx openblas/0.3.23
 #
 ########################################
 
@@ -71,7 +71,7 @@ set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
 set( ENABLE_MPI ON CACHE BOOL "" )
 
 if( NOT DEFINED ENV{HPCX_MPI_DIR} )
-    message( FATAL_ERROR "HPC-X OpenMPI is not loaded. Please load the hpcx-ompi module." )
+    message( FATAL_ERROR "HPC-X OpenMPI is not loaded. Please load the hpcx module." )
 endif()
 
 #######################################                                                                                                                                           

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
@@ -53,7 +53,7 @@ set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
 set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                )
+set( DEBUG_FLAGS   "-00 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
@@ -81,8 +81,8 @@ endif()
 # use :
 # - OpenBLAS library
 
-find_package(openblas)
+find_library(OPENBLAS_LIB openblas)
 
-if(NOT openblas_FOUND)
+if(NOT OPENBLAS_LIB)
     message(FATAL_ERROR "OpenBLAS is not loaded. Please load the openblas/0.3.23 module.")
 endif()

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
@@ -31,7 +31,7 @@
 #
 ########################################
 
-set( CONFIG_NAME "pangea4-gcc12.1-hpcxompi2.17.1-openblas/0.3.23" CACHE PATH "" )
+set( CONFIG_NAME "pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23" CACHE PATH "" )
 
 include(${CMAKE_CURRENT_LIST_DIR}/pangea4-base.cmake)
 

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
@@ -52,8 +52,8 @@ set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
-set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                      )
+set( RELEASE_FLAGS "-O3 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-O0 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
@@ -51,15 +51,19 @@ set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
 set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
-set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
-set( RELEASE_FLAGS "-DNDEBUG"                        )
+set( COMMON_FLAGS  "-march=native -mtune=native" )
+set( RELEASE_FLAGS "-03 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-00 -g"                )
 
-set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_DEBUG       ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_C_FLAGS_DEBUG         ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_DEBUG   ${DEBUG_FLAGS}   CACHE STRING "" )
 
 #######################################
 # MPI SETUP

--- a/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23.cmake
@@ -1,0 +1,88 @@
+#######################################
+#
+# Pangea4 - gcc - hpcxompi - openblas
+#
+# Uses :
+#   - cray wrappers for gcc (cc, CC, ftn)
+#   - OpenBLAS      for BLAS and LAPACK
+#   - HPC-X OpenMPI for MPI
+#
+#######################################
+#
+# Requires modules :
+#   - PrgEnv-gnu           = 8.4.0, which loads :
+#     . gcc                = 12.1
+#     . craype             = 2.7.23
+#     . cray-dsmml         = 0.2.2
+#     . craype-network-ofi = 1.0
+#     . libfabric          = 1.13.1
+#   - cmake                = 3.27.2
+#   - cray-python          = 3.10.10
+#   - craype-x86-milan     = 1.0
+#     PrgEnv-gnu loads gcc 12 that does not support craype-x86-genoa
+#   - hpcx-ompi            = 2.17.1
+#   - openblas             = 0.3.23
+#
+# Load modules this way :
+#   - module purge
+#   - module load PrgEnv-gnu/8.4.0 craype-x86-milan cmake/3.27.2 cray-python/3.10.10
+#   - module unload cray-libsci/23.09.1.1 cray-mpich/8.1.27
+#   - module load hpcx-ompi openblas/0.3.23
+#
+########################################
+
+set( CONFIG_NAME "pangea4-gcc12.1-hpcxompi2.17.1-openblas/0.3.23" CACHE PATH "" )
+
+include(${CMAKE_CURRENT_LIST_DIR}/pangea4-base.cmake)
+
+#######################################
+# COMPILER SETUP
+#######################################
+
+# use :
+#  - cray wrappers for gnu compilers so that we link properly with infiniband network
+#  - explicit optimization flags even when using cray wrappers
+
+if( NOT DEFINED ENV{GCC_PATH} )
+    message( FATAL_ERROR "GCC is not loaded. Please load the PrgEnv-gnu/8.4.0 module." )
+endif()
+
+set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
+set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
+set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
+
+set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
+set( RELEASE_FLAGS "-DNDEBUG"                        )
+
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+
+#######################################
+# MPI SETUP
+#######################################
+
+# use :
+# - HPC-X OpenMPI library
+
+set( ENABLE_MPI ON CACHE BOOL "" )
+
+if( NOT DEFINED ENV{HPCX_MPI_DIR} )
+    message( FATAL_ERROR "HPC-X OpenMPI is not loaded. Please load the hpcx-ompi module." )
+endif()
+
+#######################################                                                                                                                                           
+# BLAS/LAPACK SETUP                                                                                                                                                               
+#######################################
+
+# use :
+# - OpenBLAS library
+
+find_package(openblas)
+
+if(NOT openblas_FOUND)
+    message(FATAL_ERROR "OpenBLAS is not loaded. Please load the openblas/0.3.23 module.")
+endif()

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
@@ -1,0 +1,95 @@
+#######################################
+#
+# Pangea4 - gcc - openmpi - onemkl
+#
+# Uses :
+#   - cray wrappers for gcc (cc, CC, ftn)
+#   - OpenMPI       for MPI
+#   - oneAPI MKL    for BLAS and LAPACK
+#
+#######################################
+#
+# Requires modules :
+#   - PrgEnv-gnu           = 8.4.0, which loads :
+#     . gcc                = 12.1
+#     . craype             = 2.7.23
+#     . cray-dsmml         = 0.2.2
+#     . craype-network-ofi = 1.0
+#     . libfabric          = 1.13.1
+#   - cmake                = 3.27.2
+#   - cray-python          = 3.10.10
+#   - craype-x86-milan     = 1.0
+#     PrgEnv-gnu loads gcc 12 that does not support craype-x86-genoa
+#   - openmpi              = 4.1.6
+#   - intel-oneapi-mkl     = 2023.2.0
+#
+# Load modules this way :
+#   - module purge
+#   - module load PrgEnv-gnu/8.4.0 craype-x86-milan cmake/3.27.2 cray-python/3.10.10
+#   - module unload cray-libsci/23.09.1.1 cray-mpich/8.1.27
+#   - module load openmpi/4.1.6 intel-oneapi-mkl/2023.2.0
+#
+########################################
+
+set( CONFIG_NAME "pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0" CACHE PATH "" )
+
+include(${CMAKE_CURRENT_LIST_DIR}/pangea4-base.cmake)
+
+#######################################
+# COMPILER SETUP
+#######################################
+
+# use :
+#  - cray wrappers for gnu compilers so that we link properly with infiniband network
+#  - explicit optimization flags even when using cray wrappers
+
+if( NOT DEFINED ENV{GCC_PATH} )
+    message( FATAL_ERROR "GCC is not loaded. Please load the PrgEnv-gnu/8.4.0 module." )
+endif()
+
+set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
+set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
+set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
+
+set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
+set( RELEASE_FLAGS "-DNDEBUG"                        )
+
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+
+#######################################
+# MPI SETUP
+#######################################
+
+# use :
+# - OpenMPI library
+
+set( ENABLE_MPI ON CACHE BOOL "" )
+
+if( NOT "$ENV{LMOD_MPI_NAME}" STREQUAL "openmpi" )
+    message(FATAL_ERROR "OpenMPI is not loaded. Please load the openmpi/4.1.6 module.")
+endif()
+
+#######################################                                                                                                                                           
+# BLAS/LAPACK SETUP                                                                                                                                                               
+#######################################
+
+# use :
+# - intel oneAPI MKL library
+
+set( ENABLE_MKL ON CACHE BOOL "" FORCE )
+
+if( NOT DEFINED ENV{MKLROOT} )
+    message( FATAL_ERROR "MKL is not loaded. Please load the intel-oneapi-mkl/2023.2.0 module." )
+endif()
+
+set( MKL_INCLUDE_DIRS $ENV{MKLROOT}/include CACHE STRING "" )
+set( MKL_LIBRARIES    $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
+                      $ENV{MKLROOT}/lib/intel64/libmkl_gnu_thread.so
+                      $ENV{MKLROOT}/lib/intel64/libmkl_core.so
+                      $ENV{GCC_PATH}/lib/gcc/x86_64-redhat-linux/12/libgomp.so
+                      CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
@@ -53,7 +53,7 @@ set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
 set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                )
+set( DEBUG_FLAGS   "-00 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
@@ -88,8 +88,6 @@ if( NOT DEFINED ENV{MKLROOT} )
 endif()
 
 set( MKL_INCLUDE_DIRS $ENV{MKLROOT}/include CACHE STRING "" )
-set( MKL_LIBRARIES    $ENV{MKLROOT}/lib/intel64/libmkl_gf_lp64.so
-                      $ENV{MKLROOT}/lib/intel64/libmkl_gnu_thread.so
-                      $ENV{MKLROOT}/lib/intel64/libmkl_core.so
+set( MKL_LIBRARIES    $ENV{MKLROOT}/lib/intel64/libmkl_rt.so
                       $ENV{GCC_PATH}/lib/gcc/x86_64-redhat-linux/12/libgomp.so
                       CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
@@ -52,8 +52,8 @@ set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
-set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                      )
+set( RELEASE_FLAGS "-O3 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-O0 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0.cmake
@@ -51,15 +51,19 @@ set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
 set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
-set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
-set( RELEASE_FLAGS "-DNDEBUG"                        )
+set( COMMON_FLAGS  "-march=native -mtune=native" )
+set( RELEASE_FLAGS "-03 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-00 -g"                )
 
-set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_DEBUG       ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_C_FLAGS_DEBUG         ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_DEBUG   ${DEBUG_FLAGS}   CACHE STRING "" )
 
 #######################################
 # MPI SETUP

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
@@ -1,0 +1,88 @@
+#######################################
+#
+# Pangea4 - gcc - openmpi - openblas
+#
+# Uses :
+#   - cray wrappers for gcc (cc, CC, ftn)
+#   - OpenBLAS      for BLAS and LAPACK
+#   - oneAPI MKL    for BLAS and LAPACK
+#
+#######################################
+#
+# Requires modules :
+#   - PrgEnv-gnu           = 8.4.0, which loads :
+#     . gcc                = 12.1
+#     . craype             = 2.7.23
+#     . cray-dsmml         = 0.2.2
+#     . craype-network-ofi = 1.0
+#     . libfabric          = 1.13.1
+#   - cmake                = 3.27.2
+#   - cray-python          = 3.10.10
+#   - craype-x86-milan     = 1.0
+#     PrgEnv-gnu loads gcc 12 that does not support craype-x86-genoa
+#   - openmpi              = 4.1.6
+#   - openblas             = 0.3.23
+#
+# Load modules this way :
+#   - module purge
+#   - module load PrgEnv-gnu/8.4.0 craype-x86-milan cmake/3.27.2 cray-python/3.10.10
+#   - module unload cray-libsci/23.09.1.1 cray-mpich/8.1.27
+#   - module load openmpi/4.1.6 openblas0.3.23
+#
+########################################
+
+set( CONFIG_NAME "pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23" CACHE PATH "" )
+
+include(${CMAKE_CURRENT_LIST_DIR}/pangea4-base.cmake)
+
+#######################################
+# COMPILER SETUP
+#######################################
+
+# use :
+#  - cray wrappers for gnu compilers so that we link properly with infiniband network
+#  - explicit optimization flags even when using cray wrappers
+
+if( NOT DEFINED ENV{GCC_PATH} )
+    message( FATAL_ERROR "GCC is not loaded. Please load the PrgEnv-gnu/8.4.0 module." )
+endif()
+
+set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
+set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
+set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
+
+set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
+set( RELEASE_FLAGS "-DNDEBUG"                        )
+
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+
+#######################################
+# MPI SETUP
+#######################################
+
+# use :
+# - OpenMPI library
+
+set( ENABLE_MPI ON CACHE BOOL "" )
+
+if( NOT "$ENV{LMOD_MPI_NAME}" STREQUAL "openmpi" )
+    message(FATAL_ERROR "OpenMPI is not loaded. Please load the openmpi/4.1.6 module.")
+endif()
+
+#######################################                                                                                                                                           
+# BLAS/LAPACK SETUP                                                                                                                                                               
+#######################################
+
+# use :
+# - OpenBLAS library
+
+find_library(OPENBLAS_LIB openblas)
+
+if(NOT OPENBLAS_LIB)
+    message(FATAL_ERROR "OpenBLAS is not loaded. Please load the openblas/0.3.23 module.")
+endif()

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
@@ -53,7 +53,7 @@ set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
 set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                )
+set( DEBUG_FLAGS   "-00 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
@@ -4,7 +4,7 @@
 #
 # Uses :
 #   - cray wrappers for gcc (cc, CC, ftn)
-#   - OpenBLAS      for BLAS and LAPACK
+#   - OpenMPI       for MPI
 #   - oneAPI MKL    for BLAS and LAPACK
 #
 #######################################

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
@@ -52,8 +52,8 @@ set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
 set( COMMON_FLAGS  "-march=native -mtune=native" )
-set( RELEASE_FLAGS "-03 -DNDEBUG"                )
-set( DEBUG_FLAGS   "-00 -g"                      )
+set( RELEASE_FLAGS "-O3 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-O0 -g"                      )
 
 set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
 set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )

--- a/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
+++ b/host-configs/TOTAL/pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23.cmake
@@ -51,15 +51,19 @@ set( CMAKE_C_COMPILER       "cc"  CACHE PATH "" )
 set( CMAKE_CXX_COMPILER     "CC"  CACHE PATH "" )
 set( CMAKE_Fortran_COMPILER "ftn" CACHE PATH "" )
 
-set( COMMON_FLAGS  "-O3 -march=native -mtune=native" )
-set( RELEASE_FLAGS "-DNDEBUG"                        )
+set( COMMON_FLAGS  "-march=native -mtune=native" )
+set( RELEASE_FLAGS "-03 -DNDEBUG"                )
+set( DEBUG_FLAGS   "-00 -g"                )
 
-set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE PATH "" )
-set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE PATH "" )
-set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE PATH "" )
+set( CMAKE_C_FLAGS               ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS             ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS         ${COMMON_FLAGS}  CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_RELEASE     ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_C_FLAGS_RELEASE       ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_RELEASE ${RELEASE_FLAGS} CACHE STRING "" )
+set( CMAKE_CXX_FLAGS_DEBUG       ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_C_FLAGS_DEBUG         ${DEBUG_FLAGS}   CACHE STRING "" )
+set( CMAKE_Fortran_FLAGS_DEBUG   ${DEBUG_FLAGS}   CACHE STRING "" )
 
 #######################################
 # MPI SETUP


### PR DESCRIPTION
Adds the Pangea 4 host config files :

| host-config   | Description | Compiler | MPI | BLAS-LAPACK |
| -------- | ------- | ------- | ------- | ------- |
| pangea4-base.cmake  | base configuration for Pangea4 (CPU cluster), all libs enabled, no openMP  | X | X | X |
| pangea4-gcc12.1-hpcxompi2.17.1-onemkl2023.2.0 | default gcc build | cray wrappers for gnu (cc, CC, ftn)  | HPC-X OpenMPI | oneAPI MKL |
| pangea4-gcc12.1-openmpi4.1.6-onemkl2023.2.0 | alternative gcc build | cray wrappers for gnu (cc, CC, ftn)  | OpenMPI | oneAPI MKL |
| pangea4-gcc12.1-openmpi4.1.6-openblas0.3.23 | alternative gcc build | cray wrappers for gnu (cc, CC, ftn)  | OpenMPI | OpenBLAS |
| pangea4-gcc12.1-hpcxompi2.17.1-openblas0.3.23 | alternative gcc build | cray wrappers for gnu (cc, CC, ftn)  | HPC-X OpenMPI | OpenBLAS |

Linked to GEOS' PR [#3081](https://github.com/GEOS-DEV/GEOS/pull/3081)