### PR TITLE
Build Geos against TPLs with ENABLE_CUDA=OFF on pangea3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -797,9 +797,12 @@ if( ENABLE_HYPRE )
   endif()
 
   if( ENABLE_HYPRE_DEVICE STREQUAL "CUDA" )
-    list( APPEND HYPRE_DEPENDS chai )
-    string( SUBSTRING ${CUDA_ARCH} 3 -1 HYPRE_CUDA_SM ) # sm_XY -> XY
-    set( HYPRE_CUDA_FLAGS "\
+    if( NOT ENABLE_CUDA )
+      message( WARNING "Setting of HYPRE device to CUDA ignored because ENABLE_CUDA is OFF" )
+    else()
+      list( APPEND HYPRE_DEPENDS chai )
+      string( SUBSTRING ${CUDA_ARCH} 3 -1 HYPRE_CUDA_SM ) # sm_XY -> XY
+      set( HYPRE_CUDA_FLAGS "\
 --with-cuda --with-cuda-home=${CUDA_TOOLKIT_ROOT_DIR} \
 --enable-cusparse \
 --enable-cusolver \
@@ -809,7 +812,7 @@ if( ENABLE_HYPRE )
 --with-umpire-include=${CHAI_DIR}/include \
 --with-umpire-lib-dirs=${CHAI_DIR}/lib \
 --with-umpire-libs=umpire " )
-
+    endif()
   elseif( ENABLE_HYPRE_DEVICE STREQUAL "HIP" )
     message( FATAL_ERROR "hip tpls build only supported through spack" )
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,7 +798,7 @@ if( ENABLE_HYPRE )
 
   if( ENABLE_HYPRE_DEVICE STREQUAL "CUDA" )
     if( NOT ENABLE_CUDA )
-      message( WARNING "Setting of HYPRE device to CUDA ignored because ENABLE_CUDA is OFF" )
+      message( FATAL_ERROR "Non-compatible options: HYPRE device cannot be setted to CUDA when ENABLE_CUDA is OFF" )
     else()
       list( APPEND HYPRE_DEPENDS chai )
       string( SUBSTRING ${CUDA_ARCH} 3 -1 HYPRE_CUDA_SM ) # sm_XY -> XY

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,7 +798,7 @@ if( ENABLE_HYPRE )
 
   if( ENABLE_HYPRE_DEVICE STREQUAL "CUDA" )
     if( NOT ENABLE_CUDA )
-      message( FATAL_ERROR "Non-compatible options: HYPRE device cannot be setted to CUDA when ENABLE_CUDA is OFF" )
+      message( FATAL_ERROR "Non-compatible options: HYPRE device cannot be set to CUDA when ENABLE_CUDA is OFF" )
     else()
       list( APPEND HYPRE_DEPENDS chai )
       string( SUBSTRING ${CUDA_ARCH} 3 -1 HYPRE_CUDA_SM ) # sm_XY -> XY

--- a/host-configs/TOTAL/pangea3-gcc8.4.1-openmpi-4.1.2.cmake
+++ b/host-configs/TOTAL/pangea3-gcc8.4.1-openmpi-4.1.2.cmake
@@ -100,7 +100,10 @@ set(PETSC_OMP_DIR ${GEOSX_TPL_ROOT_DIR}/omp-links-for-petsc CACHE STRING "")
 # PETSc doesn't seem to work correctly with clang.
 set(ENABLE_PETSC OFF CACHE BOOL "")
 set(ENABLE_HYPRE ON CACHE BOOL "")
-set(ENABLE_HYPRE_DEVICE "CUDA" CACHE STRING "")
+
+if (ENABLE_CUDA)
+  set(ENABLE_HYPRE_DEVICE "CUDA" CACHE STRING "")
+endif ()
 
 set(SCOTCH_NUM_PROC 1 CACHE STRING "" )
 


### PR DESCRIPTION
Using the ThirdPartyLibraries with the `pangea3-gcc8.4.1-openmpi-4.1.2.cmake` host-config file and the `-DENABLE_CUDA=OFF` option compiles HYPRE with CUDA flags and the other TPLs without CUDA flags. This results in a set of software that can't be used to build Geos.

This PR proposes to ensure that the entire suite of TPLs is built with compatible flags (so the build of Geos will not fail): 
  1. if the `ENABLE_CUDA` variable is explicitely setted to `OFF` by the user and `Hypre` is asked to be built with `CUDA`, a warning is raised saying that Hypre will ignore the `CUDA` config.
  2. Even if useless with the previous modification, I find it useful to provide to the user host-config files where dependencies between options are explicitely shown so I have modified the P3 host-config file in order to set `Hypre device` to `CUDA` only when `ENABLE_CUDA` is `on`.

It is linked to:
  -  Geos issue : https://github.com/GEOS-DEV/GEOS/issues/3128
  - Geos PR : https://github.com/GEOS-DEV/GEOS/pull/3129
