### PR TITLE
Update to hypre v2.32.0-4-gc893886d1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -808,6 +808,7 @@ if( ENABLE_HYPRE )
 --enable-unified-memory \
 --with-gpu-arch=${HYPRE_CUDA_SM} \
 --with-umpire \
+--with-umpire-host \
 --with-umpire-include=${CHAI_DIR}/include \
 --with-umpire-lib-dirs=${CHAI_DIR}/lib \
 --with-umpire-libs=umpire " )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -808,7 +808,6 @@ if( ENABLE_HYPRE )
 --enable-unified-memory \
 --with-gpu-arch=${HYPRE_CUDA_SM} \
 --with-umpire \
---with-umpire-host \
 --with-umpire-include=${CHAI_DIR}/include \
 --with-umpire-lib-dirs=${CHAI_DIR}/lib \
 --with-umpire-libs=umpire " )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,7 +764,7 @@ endif()
 
 if( ENABLE_HYPRE )
   set( HYPRE_DIR "${CMAKE_INSTALL_PREFIX}/hypre" )
-  set( HYPRE_URL "${TPL_MIRROR_DIR}/hypre-v2.31.0-12-g06da35b1a.tar.gz" )
+  set( HYPRE_URL "${TPL_MIRROR_DIR}/hypre-v2.31.0-32-gf6bb554b4.tar.gz" )
   set( HYPRE_DEPENDS "" )
 
 

--- a/tplMirror/hypre-v2.31.0-12-g06da35b1a.tar.gz
+++ b/tplMirror/hypre-v2.31.0-12-g06da35b1a.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:121ea0eebb170fc524de45979b92316627630e096ee878a6ab1b987849dd1d52
-size 4392127

--- a/tplMirror/hypre-v2.31.0-32-gf6bb554b4.tar.gz
+++ b/tplMirror/hypre-v2.31.0-32-gf6bb554b4.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d2355d9fd5a9229ed0f46620ee5ebd1ace54a40c66fc0c35f012aac962a882d
+size 4400814


### PR DESCRIPTION
New hypre developments include:
- Host and device implementations for separate displacement components
- Improve performance of MGR's jacobi interpolation setup
- Improve performance of MGR's non-galerkin coarse grid correction
- Addition of hypre's log level feature to track host and device memory usage
- Add partial device support to HMIS coarsening in BoomerAMG
- Fix build with umpire's host pool enable
- Fix gcc-14 compilation warnings and errors
- Fix cuda >= 12.5 compilation

GEOS PR: https://github.com/GEOS-DEV/GEOS/pull/3339