### PR TITLE
Update hypre to `v2.32.0-27-g19ecc9788`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,7 +749,7 @@ if( ENABLE_MPI )
     set(SUPERLU_CXX_FLAGS "${CXX_FLAGS_NO_WARNINGS}")
     set(SUPERLU_Fortran_FLAGS "${CMAKE_Fortran_FLAGS}")
   endif()
-  
+
 
   set(PARMETIS_INCLUDE_DIRS ${CMAKE_INSTALL_PREFIX}/parmetis/include;${CMAKE_INSTALL_PREFIX}/metis/include)
   set(PARMETIS_LIBRARIES ${CMAKE_INSTALL_PREFIX}/parmetis/lib/libparmetis.a;${CMAKE_INSTALL_PREFIX}/metis/lib/libmetis.a)
@@ -795,7 +795,7 @@ endif()
 
 if( ENABLE_HYPRE )
   set( HYPRE_DIR "${CMAKE_INSTALL_PREFIX}/hypre" )
-  set( HYPRE_URL "${TPL_MIRROR_DIR}/hypre-v2.32.0-4-gc893886d1.tar.gz" )
+  set( HYPRE_URL "${TPL_MIRROR_DIR}/hypre-v2.32.0-27-g19ecc9788.tar.gz" )
   set( HYPRE_DEPENDS "" )
 
 

--- a/tplMirror/hypre-v2.32.0-27-g19ecc9788.tar.gz
+++ b/tplMirror/hypre-v2.32.0-27-g19ecc9788.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c7dba8870d0c9ac6fb4a2b9243711449b72269ef69fc6cd77245401f41c1e3f
+size 4397112

--- a/tplMirror/hypre-v2.32.0-4-gc893886d1.tar.gz
+++ b/tplMirror/hypre-v2.32.0-4-gc893886d1.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:39b47555ef21be9d1304c92bd510c9b3362ec2482311456e83cc5038f69ecef6
-size 4398725


### PR DESCRIPTION
Fixes runtime issues with cuda >= 12.4
Fixes GPU-aware runtime switch option
Fixes various build warnings
