### PR TITLE
Add mathpresso spack recipe

### DIFF
--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -82,6 +82,7 @@ class Geosx(CMakePackage, CudaPackage):
     variant('docs', default=False, description='Build docs')
     variant('addr2line', default=True,
             description='Add support for addr2line.')
+    variant('mathpresso', default=True, description='Build mathpresso.')
 
     # SPHINX_BEGIN_DEPENDS
 
@@ -188,6 +189,11 @@ class Geosx(CMakePackage, CudaPackage):
     #
     depends_on('doxygen@1.8.20', when='+docs', type='build')
     depends_on('py-sphinx@1.6.3:', when='+docs', type='build')
+
+    #
+    # Other
+    #
+    depends_on("mathpresso cxxflags='-fPIC'", when='+mathpresso')
 
     # SPHINX_END_DEPENDS
 
@@ -579,8 +585,14 @@ class Geosx(CMakePackage, CudaPackage):
             cfg.write('# Other\n')
             cfg.write('#{0}\n\n'.format('-' * 80))
 
-            cfg.write(cmake_cache_option('ENABLE_MATHPRESSO', False))
-            cfg.write(cmake_cache_option('ENABLE_XML_UPDATES', False))
+            if '+mathpresso' in spec:
+                cfg.write(cmake_cache_option('ENABLE_MATHPRESSO', True))
+                cfg.write(cmake_cache_entry('MATHPRESSO_DIR', spec['mathpresso'].prefix))
+                cfg.write(cmake_cache_option('ENABLE_XML_UPDATES', True))
+            else:
+                cfg.write(cmake_cache_option('ENABLE_MATHPRESSO', False))
+                cfg.write(cmake_cache_option('ENABLE_XML_UPDATES', False))
+
 
             # ATS
             # Lassen

--- a/scripts/spack_packages/packages/mathpresso/package.py
+++ b/scripts/spack_packages/packages/mathpresso/package.py
@@ -1,0 +1,31 @@
+from spack.package import *
+import subprocess
+
+class Mathpresso(CMakePackage):
+    """MathPresso is a mathematical expression parser and JIT compiler."""
+
+    homepage = "https://github.com/kobalicek/mathpresso"
+    git      = "https://github.com/kobalicek/mathpresso.git"
+
+    version('geos', commit='24d60e5c4d9a887c9ecb11991d07c54b3139ff1e')
+
+    depends_on("cxx", type="build")
+
+    def cmake(self, spec, prefix):
+        # Mathpresso requires asmjit source files.
+        # Clone the source files and checkout specific commit
+        with working_dir(self.stage.source_path):
+            git = which('git')
+            git('clone', 'https://github.com/asmjit/asmjit.git')
+            subprocess.run(['git', 'reset', '--hard', '2e93826348d6cd1325a8b1f7629e193c58332da9'],
+                            cwd='./asmjit')
+
+        super().cmake(spec, prefix)
+
+    def cmake_args(self):
+        args= [
+            '-DMATHPRESSO_STATIC=TRUE',
+            '-DCMAKE_CXX_STANDARD=11',
+            self.define("ASMJIT_DIR", self.stage.source_path + "/asmjit")
+        ]
+        return args


### PR DESCRIPTION
This PR:
- Creates a spack variant and recipe for mathpresso.
  -  Allows correct compilation and generation of schema (bypasses GEOS-DEV/GEOS#3407)

Relates to GEOS-DEV/GEOS#3575