### PR TITLE
refactor: move versions to geos package.py

### DIFF
--- a/scripts/spack_configs/blueos_3_ppc64le_ib_p9/spack.yaml
+++ b/scripts/spack_configs/blueos_3_ppc64le_ib_p9/spack.yaml
@@ -106,33 +106,6 @@ spack:
     hypre:
       require: "@git.21e5953ddc6daaa24699236108866afa597a415c"
 
-    # v2024.07.0
-    chai:
-      require: "@git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19=develop"
-
-    # v2024.07.0
-    umpire:
-      require: "@git.abd729f40064175e999a83d11d6b073dac4c01d2=develop"
-
-    # v2024.07.0
-    raja:
-      require: "@git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1=develop"
-
-    # v2024.07.0
-    camp:
-      require: "@git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
     superlu-dist:
       require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 

--- a/scripts/spack_configs/macOS/spack.yaml
+++ b/scripts/spack_configs/macOS/spack.yaml
@@ -42,40 +42,10 @@ spack:
         blas: [netlib-lapack]
         lapack: [netlib-lapack]
 
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
 
     # master - 10/18/24
     hypre:
       require: "@git.c893886d15eb57e87dd36efec23693ece3ddc88e"
-
-    # v2024.07.0
-    chai:
-      require: "@git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19=develop"
-
-    # v2024.07.0
-    umpire:
-      require: "@git.abd729f40064175e999a83d11d6b073dac4c01d2=develop"
-
-    # v2024.07.0
-    raja:
-      require: "@git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1=develop"
-
-    # v2024.07.0
-    camp:
-      require: "@git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
 
     superlu-dist:
       require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
@@ -120,7 +90,7 @@ spack:
       externals:
         - spec: diffutils@3.11
           prefix: /opt/homebrew/opt/diffutils
-          
+
     autoconf:
       buildable: False
       externals:
@@ -151,4 +121,16 @@ spack:
       buildable: False
       externals:
         - spec: addr2line@2.43.1
-          prefix: /opt/homebrew/opt/binutils     
+          prefix: /opt/homebrew/opt/binutils
+    
+    zlib:
+      buildable: False
+      externals:
+        - spec: zlib@1.3.1
+          prefix: /opt/homebrew/opt/zlib 
+
+    python:
+      buildable: false
+      externals:
+        - spec: python@3.13.2
+          prefix: /opt/homebrew/opt/python@3.13                    

--- a/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
@@ -102,33 +102,6 @@ spack:
     hypre:
       require: "@git.21e5953ddc6daaa24699236108866afa597a415c"
 
-    # v2024.07.0
-    chai:
-      require: "@git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19=develop"
-
-    # v2024.07.0
-    umpire:
-      require: "@git.abd729f40064175e999a83d11d6b073dac4c01d2=develop"
-
-    # v2024.07.0
-    raja:
-      require: "@git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1=develop"
-
-    # v2024.07.0
-    camp:
-      require: "@git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
     superlu-dist:
       require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -88,7 +88,7 @@ class Geosx(CMakePackage, CudaPackage):
 
     depends_on('cmake@3.24:', type='build')
 
-    depends_on('blt')
+    depends_on('blt@0.6.2')
 
     #
     # Virtual packages
@@ -100,26 +100,24 @@ class Geosx(CMakePackage, CudaPackage):
     #
     # Performance portability
     #
-    depends_on('raja ~examples~exercises~shared')
+    depends_on('raja@2024.07.0 ~examples~exercises~shared')
     depends_on("raja~openmp", when="~openmp")
     depends_on("raja+openmp", when="+openmp")
 
-    depends_on('umpire +c~examples+fortran~device_alloc~shared')
+    depends_on('umpire@2024.07.0 +c~examples+fortran~device_alloc~shared')
     depends_on("umpire~openmp", when="~openmp")
     depends_on("umpire+openmp", when="+openmp")
 
-    depends_on('chai +raja~examples~shared')
+    depends_on('chai@2024.07.0 +raja~examples~shared')
     depends_on("chai~openmp", when="~openmp")
     depends_on("chai+openmp", when="+openmp")
-
-    depends_on('camp')
 
     with when('+cuda'):
         for sm_ in CudaPackage.cuda_arch_values:
             depends_on('raja+cuda cuda_arch={0}'.format(sm_), when='cuda_arch={0}'.format(sm_))
             depends_on('umpire+cuda cuda_arch={0}'.format(sm_), when='cuda_arch={0}'.format(sm_))
             depends_on('chai+cuda~separable_compilation cuda_arch={0}'.format(sm_), when='cuda_arch={0}'.format(sm_))
-            depends_on('camp+cuda cuda_arch={0}'.format(sm_), when='cuda_arch={0}'.format(sm_))
+            depends_on('camp@v2024.07.0+cuda cuda_arch={0}'.format(sm_), when='cuda_arch={0}'.format(sm_))
 
     #
     # IO
@@ -127,10 +125,10 @@ class Geosx(CMakePackage, CudaPackage):
     depends_on('hdf5@1.12.1')
     depends_on('silo@4.11.1-bsd~fortran~shared')
 
-    depends_on('conduit~test~fortran~hdf5_compat~shared')
+    depends_on('conduit@0.9.2~test~fortran~hdf5_compat~shared')
 
     depends_on('adiak@0.4.0 ~shared', when='+caliper')
-    depends_on('caliper~gotcha~sampler~libunwind~libdw', when='+caliper')
+    depends_on('caliper@v2.12.0~gotcha~sampler~libunwind~libdw', when='+caliper')
 
     depends_on('pugixml@1.13 ~shared')
 
@@ -182,7 +180,7 @@ class Geosx(CMakePackage, CudaPackage):
     #
     # Dev tools
     #
-    depends_on('uncrustify', when='+uncrustify')
+    depends_on('uncrustify@0.80.1', when='+uncrustify')
 
     #
     # Documentation


### PR DESCRIPTION
Trying to force the definition of the versions of all tpls in the geosx `package.py`. This should ensure that we don't need to specify the commit in all environments and it should make updating a version easier. 