### PR TITLE
Add Spack configuration for Pine

### DIFF
--- a/scripts/spack_configs/pine/spack.yaml
+++ b/scripts/spack_configs/pine/spack.yaml
@@ -1,0 +1,191 @@
+# This is a Spack Environment file for Pine.
+#
+# It describes a set of packages to be installed, along with
+# configuration settings.
+#
+# Run command from the top-level of the repository:
+# ./scripts/uberenv/uberenv.py                                  \
+#    --spec "%gcc@11.4.1 ~openmp~pygeosx~docs"                  \
+#    --spack-env-file=scripts/spack_configs/pine/spack.yaml     \
+#    --project-json=.uberenv_config.json                        \
+#    --prefix ${GEOS_TPL_DIR}
+spack:
+  config:
+    install_tree:
+      root: $spack/..
+      projections:
+        all: '{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
+    misc_cache: $spack/../misc_cache
+    test_stage: $spack/../test_stage
+    build_stage:
+      - $spack/../build_stage
+  # Regular TPLs do not need views
+  view: false
+
+  #############
+  # COMPILERS #
+  #############
+  compilers:
+  - compiler:
+      spec: gcc@11.4.1
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags:
+        cflags: -march=native -mtune=native
+        cxxflags: -march=native -mtune=native
+      operating_system: rocky9
+      target: x86_64
+      modules: []
+      environment:
+        set: # Needed for scotch
+          BISON: bison
+          FLEX: flex
+      extra_rpaths: []
+
+  #############
+  # PACKAGES  #
+  #############
+  packages:
+    all:
+      target: [zen4]
+      compiler: [gcc]
+      providers:
+        blas: [intel-mkl]
+        lapack: [intel-mkl]
+        mpi: [openmpi]
+
+    ####
+    # make sure spack doesn't rebuild mpi, blas and lapack libs
+    mpi:
+      buildable: false
+    blas:
+      buildable: false
+    lapack:
+      buildable: false
+
+    ####
+    # spec of packages to build for
+
+    # v0.6.2
+    blt:
+      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
+    # v2.32.0-33
+    hypre:
+      require: "@git.21e5953ddc6daaa24699236108866afa597a415c"
+    # v2025.0.3
+    chai:
+      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
+    # v2025.0.3.0
+    umpire:
+      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
+    # v2025.0.3.0
+    raja:
+      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
+    # v2025.0.3.0
+    camp:
+      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
+    # v2.12.0
+    caliper:
+      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
+    # v0.9.2
+    conduit:
+      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
+    # master - 04/12/20
+    uncrustify:
+      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
+    # master - 04/26/20
+    superlu-dist:
+      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
+
+    ####
+    # spec of spack packages to reuse
+    bison:
+      externals:
+      - spec: bison@3.8.2
+        prefix: /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/bison-3.8.2-ws5cszsf5536mcdqj3zbt7uynp6ho756/
+      buildable: false
+    gmp:
+      externals:
+      - spec: gmp@6.3.0
+        prefix: /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/gmp-6.3.0-q4glkxa77fd4rejkrrsuydut2c222fkm
+      buildable: false
+    mpfr:
+      externals:
+      - spec: mpfr@4.2.0
+        prefix: /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/mpfr-4.2.1-eaxjflobjpilpwfe4aalusexhcxhptrf
+      buildable: false      
+    libiconv:
+      externals:
+      - spec: libiconv@1.17
+        prefix: /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/libiconv-1.17-crgtppb7hj54qwkl3hfc6ejyu34gsa4d
+      buildable: false
+    perl:
+      externals:
+      - spec: perl@5.38.2
+        prefix: /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/perl-5.38.2-wxq42supt6zs3f63ajjtp6423q6teyot
+      buildable: false
+    berkeley-db:
+      externals:
+      - spec: berkeley-db@18.1.40
+        prefix: /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/berkeley-db-18.1.40-nixwddyxlb523z3aly4b7bje4rfft3me
+      buildable: false
+    cmake:
+      externals:
+      - spec: cmake@3.29.6
+        prefix: /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/cmake-3.29.6-i23jd7kq7lyqvrpsguhznfhoy4mso6up
+      buildable: false
+
+    ####
+    # spec of system packages to reuse
+    # bin
+    flex:
+      externals:
+      - spec: flex@2.6.4+lex
+        prefix: /usr
+      buildable: false
+    git:
+      externals:
+      - spec: git@2.39.3~tcltk
+        prefix: /usr
+      buildable: false
+    gmake:
+      externals:
+      - spec: gmake@4.3
+        prefix: /usr
+      buildable: false
+    m4:
+      externals:
+      - spec: m4@1.4.19
+        prefix: /usr
+      buildable: false
+    python:
+      buildable: False
+      externals:
+      - spec: python@3.9.18
+        prefix: /usr
+    #lib
+    openmpi:
+      externals:
+      - spec: openmpi@5.0.5
+        prefix: /hrtc/apps/mpi/openmpi/x86_64/rocky9/5.0.5/gcc/11.4.1/nocuda/
+      buildable: false
+    intel-mkl:
+      externals:
+      - spec: intel-mkl@219.5.281
+        prefix: /apps/intel/2019/u5/compilers_and_libraries_2019.5.281/linux/mkl/
+      buildable: false
+    pkgconf:
+      externals:
+      - spec: pkgconf@3.0.0
+        prefix: /usr
+      buildable: false
+    readline:
+      externals:
+      - spec: readline@8.1
+        prefix: /usr
+      buildable: false        
+
+


### PR DESCRIPTION
Add Spack configuration for Pine based on :
- gcc@11.4.1
- openmpi@5.0.5

Prerequisites:
- Redirect your ~/.spack folder to a different filer with a larger space quota 

Known limitations:
- Successfully tested with the following options: `~openmp+pygeosx+docs` or `~openmp~pygeosx~docs`
- Fails with `~openmp~pygeosx+docs` due to `py-sphinx` issue