### PR TITLE
refactor: Consolidate shared package versions for spack.yaml files

### DIFF
--- a/docker/Stanford/Dockerfile
+++ b/docker/Stanford/Dockerfile
@@ -23,6 +23,7 @@ RUN yum install -y \
     # xz \
     unzip \
     bzip2 \
+    gnupg \
     && pip3 install virtualenv
 
 # Set locale to bypass ascii codec decode error

--- a/docker/TotalEnergies/Dockerfile
+++ b/docker/TotalEnergies/Dockerfile
@@ -22,6 +22,7 @@ RUN yum install --disablerepo=intel-mkl-repo -y \
     # xz \
     unzip \
     bzip2 \
+    gnupg2 \
     && pip3 install virtualenv
 
 # Install clingo for Spack

--- a/docker/TotalEnergies/Pangea3.Dockerfile
+++ b/docker/TotalEnergies/Pangea3.Dockerfile
@@ -18,6 +18,7 @@ RUN dnf clean all && \
         automake \
         libtool \
         bzip2 \
+        gnupg2 \
         unzip
 
 # All the environment variables defined in this Dockerfile

--- a/docker/TotalEnergies/pecan.Dockerfile
+++ b/docker/TotalEnergies/pecan.Dockerfile
@@ -34,6 +34,7 @@ RUN yum install -y \
     gcc-c++ \
     wget \
     bzip2 \
+    gnupg \
     zlib-devel
 
 WORKDIR /tmp/src

--- a/docker/pangea-spack.yaml
+++ b/docker/pangea-spack.yaml
@@ -14,8 +14,8 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
 
   compilers::
   - compiler:

--- a/docker/pangea-spack.yaml
+++ b/docker/pangea-spack.yaml
@@ -12,6 +12,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   compilers::
   - compiler:
       spec: gcc@=9.4.0
@@ -40,44 +45,6 @@ spack:
         blas: [openblas]
         lapack: [openblas]
         mpi: [openmpi]
-
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
-    hypre:
-      require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
-
-    # v2025.0.3.0
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     autoconf:
       externals:

--- a/docker/pecan-spack.yaml
+++ b/docker/pecan-spack.yaml
@@ -14,8 +14,8 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
 
   compilers::
   # Pecan CPU/GPU compiler

--- a/docker/pecan-spack.yaml
+++ b/docker/pecan-spack.yaml
@@ -12,6 +12,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   compilers::
   # Pecan CPU/GPU compiler
   - compiler:
@@ -41,44 +46,6 @@ spack:
         blas: [intel-mkl]
         lapack: [intel-mkl]
         mpi: [openmpi]
-
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
-    hypre:
-      require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
-
-    # v2025.0.3.0
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     autoconf:
       version: [2.71]

--- a/docker/rocky-spack.yaml
+++ b/docker/rocky-spack.yaml
@@ -12,6 +12,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   compilers::
   - compiler:
       environment:
@@ -58,44 +63,6 @@ spack:
         blas: [netlib-lapack]
         lapack: [netlib-lapack]
         mpi: [openmpi]
-
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
-    hypre:
-      require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
-
-    # v2025.0.3.0
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     autoconf:
       version: [2.71]

--- a/docker/rocky-spack.yaml
+++ b/docker/rocky-spack.yaml
@@ -14,8 +14,8 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
 
   compilers::
   - compiler:

--- a/docker/spack.yaml
+++ b/docker/spack.yaml
@@ -12,6 +12,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   compilers::
   - compiler:
       environment:
@@ -144,44 +149,6 @@ spack:
         blas: [netlib-lapack]
         lapack: [netlib-lapack]
         mpi: [openmpi]
-
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
-    hypre:
-      require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
-
-    # v2025.0.3.0
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     autoconf:
       version: [2.71]

--- a/docker/spack.yaml
+++ b/docker/spack.yaml
@@ -14,8 +14,9 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
+
 
   compilers::
   - compiler:

--- a/docker/stanford-spack.yaml
+++ b/docker/stanford-spack.yaml
@@ -13,6 +13,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   compilers::
   # Sherlock CPU/GPU Compiler (centos7 x86_64)
   - compiler:
@@ -42,43 +47,6 @@ spack:
         mpi: [openmpi]
         blas: [openblas]
         lapack: [openblas]
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
-    hypre:
-      require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
-
-    # v2025.0.3.0
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     autoconf:
       buildable: false

--- a/docker/stanford-spack.yaml
+++ b/docker/stanford-spack.yaml
@@ -15,8 +15,8 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
 
   compilers::
   # Sherlock CPU/GPU Compiler (centos7 x86_64)

--- a/docker/tpl-centos-gcc-cuda.Dockerfile
+++ b/docker/tpl-centos-gcc-cuda.Dockerfile
@@ -48,6 +48,7 @@ RUN yum -y install \
     # xz \
     unzip \
     bzip2 \
+    gnupg \
     && pip3 install virtualenv
 
 # Install clingo for Spack

--- a/docker/tpl-rockylinux-clang-cuda-12.Dockerfile
+++ b/docker/tpl-rockylinux-clang-cuda-12.Dockerfile
@@ -28,6 +28,7 @@ RUN dnf clean all && \
         unzip \
         mpfr-devel \
         bzip2 \
+        gnupg \
         xz \
         python3-virtualenv
 

--- a/docker/tpl-rockylinux-gcc-cuda-12.Dockerfile
+++ b/docker/tpl-rockylinux-gcc-cuda-12.Dockerfile
@@ -27,6 +27,7 @@ RUN dnf clean all && \
         unzip \
         mpfr-devel \
         bzip2 \
+        gnupg \
         xz \
         python3-virtualenv
 

--- a/docker/tpl-ubuntu-clang-cuda.Dockerfile
+++ b/docker/tpl-ubuntu-clang-cuda.Dockerfile
@@ -33,6 +33,8 @@ RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
         unzip \
         libmpfr-dev \
         lbzip2 \
+        bzip2 \
+        gnupg \
         virtualenv
 
 # Install clingo for Spack

--- a/docker/tpl-ubuntu-clang.Dockerfile
+++ b/docker/tpl-ubuntu-clang.Dockerfile
@@ -38,6 +38,8 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles \
     unzip \
     libmpfr-dev \
     lbzip2 \
+    bzip2 \
+    gnupg \
     virtualenv
 
 # Install clingo for Spack

--- a/docker/tpl-ubuntu-gcc.Dockerfile
+++ b/docker/tpl-ubuntu-gcc.Dockerfile
@@ -63,6 +63,8 @@ RUN DEBIAN_FRONTEND=noninteractive TZ=America/Los_Angeles \
     unzip \
     libmpfr-dev \
     lbzip2 \
+    bzip2 \
+    gnupg \
     virtualenv
 
 # Install clingo for Spack

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -41,10 +41,10 @@ fi
 
 echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR..."
 
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12      "%gcc@12.1.1 +docs"   "salloc -n 56 -p pdebug" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12noAVX "%gcc@12noAVX +docs"  "salloc -n 56 -p pdebug" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-13      "%gcc@13.3.1 +docs"   "salloc -n 56 -p pdebug" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane clang-14    "%clang@14.0.6 +docs" "salloc -n 56 -p pdebug" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12      "%gcc@12.1.1 +docs"   "salloc -n 112 --exclusive -p pdebug" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12noAVX "%gcc@12noAVX +docs"  "salloc -n 112 --exclusive -p pdebug" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-13      "%gcc@13.3.1 +docs"   "salloc -n 112 --exclusive -p pdebug" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane clang-14    "%clang@14.0.6 +docs" "salloc -n 112 --exclusive -p pdebug" $@ &
 ./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 ./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen gcc-12-cuda-12 "%gcc@12.2.1+cuda~uncrustify cuda_arch=70 ^cuda@12.2.2+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 ./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -41,10 +41,10 @@ fi
 
 echo "Building all LC TPLs from $GEOS_BRANCH to be installed at $INSTALL_DIR..."
 
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12 "%gcc@12.1.1 +docs" "salloc -N 1 -n 1 -t 150 -A vortex" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12noAVX "%gcc@12noAVX +docs" "salloc -N 1 -n 1 -t 150 -A vortex" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-13 "%gcc@13.3.1 +docs" "salloc -N 1 -n 1 -t 150 -A vortex" $@ &
-./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane clang-14 "%clang@14.0.6 +docs" "salloc -N 1 -n 1 -t 150 -A vortex" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12      "%gcc@12.1.1 +docs"   "salloc -n 56 -p pdebug" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-12noAVX "%gcc@12noAVX +docs"  "salloc -n 56 -p pdebug" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane gcc-13      "%gcc@13.3.1 +docs"   "salloc -n 56 -p pdebug" $@ &
+./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR dane clang-14    "%clang@14.0.6 +docs" "salloc -n 56 -p pdebug" $@ &
 ./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen gcc-8-cuda-11 "%gcc@8.3.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 ./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen gcc-12-cuda-12 "%gcc@12.2.1+cuda~uncrustify cuda_arch=70 ^cuda@12.2.2+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &
 ./scripts/setupLC-TPL-uberenv-helper.bash $INSTALL_DIR lassen clang-13-cuda-11 "%clang@13.0.1+cuda~uncrustify cuda_arch=70 ^cuda@11.8.0+allow-unsupported-compilers" "lalloc 1 -W 150" $@ &

--- a/scripts/spack_configs/blueos_3_ppc64le_ib_p9/spack.yaml
+++ b/scripts/spack_configs/blueos_3_ppc64le_ib_p9/spack.yaml
@@ -39,6 +39,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../defaults.yaml
+  - ../versions.yaml
+
   compilers::
   - compiler:
       spec: clang@10.0.1
@@ -116,43 +121,6 @@ spack:
         mpi: [spectrum-mpi]
         blas: [essl]
         lapack: [essl]
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
-    hypre:
-      require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
-
-    # v2025.0.3.0
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     spectrum-mpi:
       buildable: False

--- a/scripts/spack_configs/defaults.yaml
+++ b/scripts/spack_configs/defaults.yaml
@@ -1,0 +1,16 @@
+#------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+# Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+# Copyright (c) 2018-2020 TotalEnergies
+# Copyright (c) 2019-     GEOSX Contributors
+# All rights reserved
+#
+# See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+#------------------------------------------------------------------------------------------------------------
+
+#
+# This file lists the default package variants for geos's dependencies
+# (empty for now - default variants defined in the package.py for geos)
+#

--- a/scripts/spack_configs/macOS/spack.yaml
+++ b/scripts/spack_configs/macOS/spack.yaml
@@ -14,8 +14,8 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
 
   compilers:
     - compiler:

--- a/scripts/spack_configs/macOS/spack.yaml
+++ b/scripts/spack_configs/macOS/spack.yaml
@@ -12,6 +12,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   compilers:
     - compiler:
         spec: apple-clang@16.0.0
@@ -70,44 +75,6 @@ spack:
       externals:
         - spec: openblas@0.3.29
           prefix: /opt/homebrew/opt/openblas
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
-    # master - 10/18/24
-    hypre:
-      require: "@git.c893886d15eb57e87dd36efec23693ece3ddc88e"
-
-    # v2024.07.0
-    chai:
-      require: "@git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19=develop"
-
-    # v2024.07.0
-    umpire:
-      require: "@git.abd729f40064175e999a83d11d6b073dac4c01d2=develop"
-
-    # v2024.07.0
-    raja:
-      require: "@git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1=develop"
-
-    # v2024.07.0
-    camp:
-      require: "@git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     # Lock down which MPI we are using
     openmpi:

--- a/scripts/spack_configs/maple/spack.yaml
+++ b/scripts/spack_configs/maple/spack.yaml
@@ -22,6 +22,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../defaults.yaml
+  - ../versions.yaml
+
   #############
   # COMPILERS #
   #############
@@ -64,40 +69,6 @@ spack:
 
     mathpresso:
       buildable: false
-
-    ####
-    # spec of packages to build for
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-    # v2.32.0-33
-    hypre:
-      require: "@git.21e5953ddc6daaa24699236108866afa597a415c"
-    # v2025.0.3
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-    # master - 04/12/20
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-    # master - 04/26/20
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     ####
     # spec of spack packages to reuse

--- a/scripts/spack_configs/pangea-3/spack.yaml
+++ b/scripts/spack_configs/pangea-3/spack.yaml
@@ -26,8 +26,8 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
 
   #############
   # COMPILERS #

--- a/scripts/spack_configs/pangea-3/spack.yaml
+++ b/scripts/spack_configs/pangea-3/spack.yaml
@@ -24,6 +24,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   #############
   # COMPILERS #
   #############
@@ -72,40 +77,6 @@ spack:
       buildable: false
     lapack:
       buildable: false
-
-    ####
-    # spec of packages to build for
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-    # v2.32.0-33
-    hypre:
-      require: "@git.21e5953ddc6daaa24699236108866afa597a415c"
-    # v2025.0.3
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-    # master - 04/12/20
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-    # master - 04/26/20
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     ####
     # spec of spack packages to reuse

--- a/scripts/spack_configs/pangea-4/spack.yaml
+++ b/scripts/spack_configs/pangea-4/spack.yaml
@@ -25,8 +25,8 @@ spack:
 
   # Include shared variants and versions
   include:
-  - ../scripts/spack_configs/defaults.yaml
-  - ../scripts/spack_configs/versions.yaml
+  - ../defaults.yaml
+  - ../versions.yaml
 
   #############
   # COMPILERS #

--- a/scripts/spack_configs/pangea-4/spack.yaml
+++ b/scripts/spack_configs/pangea-4/spack.yaml
@@ -23,6 +23,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../scripts/spack_configs/defaults.yaml
+  - ../scripts/spack_configs/versions.yaml
+
   #############
   # COMPILERS #
   #############
@@ -69,40 +74,6 @@ spack:
       buildable: false
     lapack:
       buildable: false
-
-    ####
-    # spec of packages to build for
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-    # v2.32.0-33
-    hypre:
-      require: "@git.21e5953ddc6daaa24699236108866afa597a415c"
-    # v2025.0.3
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-    # master - 04/12/20
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-    # master - 04/26/20
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     ####
     # spec of spack packages to reuse

--- a/scripts/spack_configs/pine/spack.yaml
+++ b/scripts/spack_configs/pine/spack.yaml
@@ -22,6 +22,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../defaults.yaml
+  - ../versions.yaml
+
   #############
   # COMPILERS #
   #############
@@ -61,40 +66,6 @@ spack:
       buildable: false
     lapack:
       buildable: false
-
-    ####
-    # spec of packages to build for
-
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-    # v2.32.0-33
-    hypre:
-      require: "@git.907a2d07b64fe47bdde4540c54665c83ced83a2c"
-    # v2025.0.3
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-    # master - 04/12/20
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-    # master - 04/26/20
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
     ####
     # spec of spack packages to reuse

--- a/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
@@ -37,6 +37,11 @@ spack:
   # Regular TPLs do not need views
   view: false
 
+  # Include shared variants and versions
+  include:
+  - ../defaults.yaml
+  - ../versions.yaml
+
   compilers::
   - compiler:
       spec: clang@14.0.6
@@ -95,42 +100,7 @@ spack:
         blas: [intel-oneapi-mkl]
         lapack: [intel-oneapi-mkl]
 
-    # v0.6.2
-    blt:
-      require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
 
-    hypre:
-      require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
-
-    # v2025.0.3.0
-    chai:
-      require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-    # v2025.0.3.0
-    umpire:
-      require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-    # v2025.0.3.0
-    raja:
-      require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-    # v2025.0.3.0
-    camp:
-      require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
-    # v2.12.0
-    caliper:
-      require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
-    # v0.9.2
-    conduit:
-      require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
-    uncrustify:
-      require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
-
-    superlu-dist:
-      require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"
 
    # Lock down which MPI we are using
     mvapich2:

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -1,0 +1,55 @@
+#------------------------------------------------------------------------------------------------------------
+# SPDX-License-Identifier: LGPL-2.1-only
+#
+# Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+# Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+# Copyright (c) 2018-2020 TotalEnergies
+# Copyright (c) 2019-     GEOSX Contributors
+# All rights reserved
+#
+# See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+#------------------------------------------------------------------------------------------------------------
+
+#
+# This file lists the package versions for geos's dependencies
+#
+packages:
+  # v0.6.2
+  blt:
+    require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
+
+  # master - 05/05/25
+  hypre:
+    require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
+
+  # v2025.0.3.0
+  chai:
+    require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
+
+  # v2025.0.3.0
+  umpire:
+    require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
+
+  # v2025.0.3.0
+  raja:
+    require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
+
+  # v2025.0.3.0
+  camp:
+    require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
+
+  # v2.12.0
+  caliper:
+    require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
+
+  # v0.9.2
+  conduit:
+    require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
+
+  # master - 04/12/20
+  uncrustify:
+    require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"
+
+  # master - 04/26/20
+  superlu-dist:
+    require: "@git.0f6efc377df2440c235452d13d28d2c717f832a1"

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -18,9 +18,9 @@ packages:
   blt:
     require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
 
-  # master - 05/05/25
+  # master - 06/27/25
   hypre:
-    require: "@git.be52325a3ed8923fb93af348b1262ecfe44ab5d2"
+    require: "@git.907a2d07b64fe47bdde4540c54665c83ced83a2c"
 
   # v2025.0.3.0
   chai:


### PR DESCRIPTION
This PR:
- Updates uberenv submodule commit hash for new feature added in LLNL/uberenv#141
- Moves redundant version information into `versions.yaml`, addressing one of the issues discussed in #305, where the same version information does not need to be specified in every `spack.yaml` file.

See GEOS-DEV/GEOS#3697 for testing.