### PR TITLE
Move scotch to CMake-based build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-build-*/
-install-*/
+/build*
+/install*
 .cproject
 .project
 .pydevproject
+.vscode/
 spack-*.txt
 __pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,7 +980,7 @@ endif(ENABLE_SUITESPARSE)
 
 if( ENABLE_SCOTCH )
     set( SCOTCH_DIR "${CMAKE_INSTALL_PREFIX}/scotch" )
-    set( SCOTCH_URL "${TPL_MIRROR_DIR}/scotch-v7.0.3.tar.gz" )
+    set( SCOTCH_URL "${TPL_MIRROR_DIR}/scotch-v7.0.7.tar.gz" )
 
     message( STATUS "Building SCOTCH found at ${SCOTCH_URL}" )
 
@@ -988,53 +988,34 @@ if( ENABLE_SCOTCH )
         message( FATAL_ERROR "Building Scotch without MPI is not supported." )
     endif()
 
-    set( SCOTCH_C_FLAGS "${C_FLAGS_NO_WARNINGS} ${CMAKE_C_FLAGS_${BUILD_TYPE_UPPER}} -Wno-error=implicit-function-declaration -fPIC -DINTSIZE64 -DIDXSIZE64 -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DSCOTCH_METIS_PREFIX -Drestrict=__restrict" )
-    set( SCOTCH_LD_FLAGS "-lm" )
-
     # OSX does not have pthread barriers used by Scotch
-    if( NOT CMAKE_HOST_APPLE )
-        set( SCOTCH_C_FLAGS "${SCOTCH_C_FLAGS} -DCOMMON_PTHREAD -DSCOTCH_PTHREAD_MPI" )
-        set( SCOTCH_LD_FLAGS "${SCOTCH_LD_FLAGS} -pthread" )
+    set( SCOTCH_THREADS ON )
+    if( CMAKE_HOST_APPLE )
+        set( SCOTCH_THREADS OFF )
     endif()
 
-    set( SCOTCH_CONFIG "\
-EXE       =
-OBJ       = .o
-LIB       = .a
-MAKE      = make
-AR        = ar
-ARFLAGS   = -ruv
-CAT       = cat
-CCS       = ${MPI_C_COMPILER}
-CCP       = ${MPI_C_COMPILER}
-CCD       = ${MPI_C_COMPILER}
-CFLAGS    = ${SCOTCH_C_FLAGS}
-CLIBFLAGS =
-LDFLAGS   = ${SCOTCH_LD_FLAGS}
-CP        = cp
-FLEX      = flex
-LN        = ln
-MKDIR     = mkdir -p
-MV        = mv
-RANLIB    = ranlib
-BISON     = bison
-prefix    = ${SCOTCH_DIR}
-" )
-
-    file(WRITE ${PROJECT_BINARY_DIR}/scotch_makefile.inc "${SCOTCH_CONFIG}")
-    set( SCOTCH_BUILD_DIR "${PROJECT_BINARY_DIR}/scotch/src/scotch/src" )
-    if ( NOT DEFINED SCOTCH_NUM_PROC )
-      set( SCOTCH_NUM_PROC 2 )
-    endif()
     ExternalProject_Add( scotch
-                         URL ${SCOTCH_URL}
-                         PREFIX ${PROJECT_BINARY_DIR}/scotch
-                         INSTALL_DIR ${SCOTCH_DIR}
-                         BINARY_DIR ${SCOTCH_BUILD_DIR}
-                         CONFIGURE_COMMAND cp ${PROJECT_BINARY_DIR}/scotch_makefile.inc ${SCOTCH_BUILD_DIR}/Makefile.inc
-                         BUILD_COMMAND make -j 2 ptscotch scotch ptesmumps esmumps
-                         INSTALL_COMMAND make install
-                       )
+                        PREFIX ${PROJECT_BINARY_DIR}/scotch
+                        URL ${SCOTCH_URL}
+                        INSTALL_DIR ${SCOTCH_DIR}
+                        BUILD_COMMAND ${TPL_BUILD_COMMAND}
+                        INSTALL_COMMAND ${TPL_INSTALL_COMMAND}
+                        CMAKE_GENERATOR ${TPL_GENERATOR}
+                        CMAKE_ARGS -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+                                    -D BUILD_PTSCOTCH:BOOL=ON
+                                    -D BUILD_LIBSCOTCHMETIS:BOOL=OFF
+                                    -D THREADS:BOOL=${SCOTCH_THREADS}
+                                    -D INTSIZE:STRING=64
+                                    -D SCOTCH_RANDOM:STRING=FIXED_SEED
+                                    -D CMAKE_C_COMPILER=${MPI_C_COMPILER}
+                                    -D CMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}
+                                    -D CMAKE_C_FLAGS=${C_FLAGS_NO_WARNINGS}
+                                    -D CMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
+                                    -D CMAKE_CXX_FLAGS=${CXX_FLAGS_NO_WARNINGS}
+                                    -D CMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
+                                    -D CMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
+                                    -D CMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+                                    )
 
     list(APPEND build_list scotch )
 

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -148,7 +148,7 @@ class Geosx(CMakePackage, CudaPackage):
     depends_on("superlu-dist+openmp", when="+openmp")
 
     # -Wno-error=implicit-function-declaration needed for 'METIS_PartMeshDual' error
-    depends_on("scotch@7.0.3 ~compression +mpi +esmumps +int64 ~shared ~metis build_system=makefile cflags='-fPIC -Wno-error=implicit-function-declaration' cxxflags='-fPIC'", when='+scotch')
+    depends_on("scotch@7.0.7 ~compression +mpi +esmumps +int64 ~shared ~metis build_system=cmake cflags='-fPIC' cxxflags='-fPIC'", when='+scotch')
 
     depends_on('suite-sparse@5.10.1')
     depends_on("suite-sparse~openmp", when="~openmp")
@@ -170,7 +170,7 @@ class Geosx(CMakePackage, CudaPackage):
         for sm_ in CudaPackage.cuda_arch_values:
             depends_on('hypre+cuda cuda_arch={0}'.format(sm_), when='cuda_arch={0}'.format(sm_))
 
-    depends_on('petsc@3.13.0~hdf5~hypre+int64', when='+petsc')
+    depends_on('petsc@3.19.4~hdf5~hypre+int64', when='+petsc')
     depends_on('petsc+ptscotch', when='+petsc+scotch')
 
     #
@@ -479,7 +479,7 @@ class Geosx(CMakePackage, CudaPackage):
             if '+caliper' in spec:
                 cfg.write(cmake_cache_option('ENABLE_CALIPER', True))
                 cfg.write(cmake_cache_entry('CALIPER_DIR', spec['caliper'].prefix))
-                cfg.write(cmake_cache_entry('adiak_DIR', spec['adiak'].prefix + '/lib/cmake/adiak'))
+                cfg.write(cmake_cache_entry('ADIAK_DIR', spec['adiak'].prefix))
 
             for tpl, cmake_name, enable in io_tpls:
                 if enable:

--- a/scripts/spack_packages/packages/scotch/esmumps-ldflags-6.0.4.patch
+++ b/scripts/spack_packages/packages/scotch/esmumps-ldflags-6.0.4.patch
@@ -1,0 +1,11 @@
+--- a/src/esmumps/Makefile	2017-06-21 10:53:31.595758201 +0200
++++ b/src/esmumps/Makefile	2017-06-21 10:54:30.811757141 +0200
+@@ -44,7 +44,7 @@
+ 				$(CC) $(CFLAGS) $(CLIBFLAGS) -I$(includedir) -c $(<) -o $(@)
+ 
+ %$(EXE)	:	%.c
+-		 		$(CC) $(CFLAGS) -I$(includedir) $(<) -o $(@) -L$(libdir) $(LDFLAGS) -L. -l$(ESMUMPSLIB) -l$(SCOTCHLIB) -lscotch -l$(SCOTCHLIB)errexit -lm
++		 		$(CC) $(CFLAGS) -I$(includedir) $(<) -o $(@) -L$(libdir) -L. -l$(ESMUMPSLIB) -l$(SCOTCHLIB) -lscotch -l$(SCOTCHLIB)errexit -lm $(LDFLAGS)
+ 
+ ##
+ ##  Project rules.

--- a/scripts/spack_packages/packages/scotch/libscotch-scotcherr-link-7.0.1.patch
+++ b/scripts/spack_packages/packages/scotch/libscotch-scotcherr-link-7.0.1.patch
@@ -1,0 +1,20 @@
+--- a/src/libscotch/CMakeLists.txt
++++ b/src/libscotch/CMakeLists.txt
+@@ -508,7 +508,7 @@ add_library(scotch
+ set_target_properties(scotch PROPERTIES VERSION
+   ${SCOTCH_VERSION}.${SCOTCH_RELEASE}.${SCOTCH_PATCHLEVEL})
+ add_dependencies(scotch parser_yy_c parser_ll_c)
+-target_link_libraries(scotch PUBLIC m)
++target_link_libraries(scotch PUBLIC m scotcherr)
+ target_include_directories(scotch PUBLIC
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+@@ -748,7 +748,7 @@ if(BUILD_PTSCOTCH)
+   set_target_properties(ptscotch PROPERTIES
+     VERSION ${SCOTCH_VERSION}.${SCOTCH_RELEASE}.${SCOTCH_PATCHLEVEL}
+     COMPILE_FLAGS -DSCOTCH_PTSCOTCH)
+-  target_link_libraries(ptscotch PUBLIC scotch MPI::MPI_C)
++  target_link_libraries(ptscotch PUBLIC ptscotcherr scotch MPI::MPI_C)
+   target_include_directories(ptscotch PUBLIC
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/scripts/spack_packages/packages/scotch/libscotchmetis-return-6.0.5a.patch
+++ b/scripts/spack_packages/packages/scotch/libscotchmetis-return-6.0.5a.patch
@@ -1,0 +1,10 @@
+--- a/src/libscotchmetis/metis_graph_part.c	2018-07-13 14:25:50.000000000 -0500
++++ b/src/libscotchmetis/metis_graph_part.c	2018-07-13 14:21:08.000000000 -0500
+@@ -298,7 +298,7 @@
+
+     edgenbr = xadj[vertnbr] - baseval;
+     if ((edlotax = memAlloc (edgenbr * sizeof (SCOTCH_Num))) == NULL)
+-      return;
++      return (METIS_ERROR);
+     edlotax -= baseval;                           /* Base access to edlotax */
+     vsiztax  = vsize2 - baseval;

--- a/scripts/spack_packages/packages/scotch/metis-headers-6.0.4.patch
+++ b/scripts/spack_packages/packages/scotch/metis-headers-6.0.4.patch
@@ -1,0 +1,634 @@
+--- A/src/libscotch/Makefile	2014-09-23 21:28:28.000000000 +0200
++++ B/src/libscotch/Makefile	2015-07-24 12:51:31.357132922 +0200
+@@ -60,7 +60,7 @@ scotch				:
+ 					libscotcherrexit$(LIB)
+ 
+ ptscotch			:	scotch
+-					$(MAKE) CFLAGS="$(CFLAGS) -DSCOTCH_PTSCOTCH" CC="$(CCP)"	\
++					$(MAKE) CFLAGS="$(CFLAGS) -DSCOTCH_PTSCOTCH" CC="$(CCP)" CCD="$(CCP)"	\
+ 					ptscotch.h							\
+ 					ptscotchf.h							\
+ 					libptscotch$(LIB)						\
+--- A/src/libscotchmetis/Makefile	2011-09-06 18:46:48.000000000 +0200
++++ B/src/libscotchmetis/Makefile	2015-08-25 13:37:31.424467916 +0200
+@@ -54,10 +54,12 @@ include ../Makefile.inc
+ 
+ scotch				:
+ 					$(MAKE) CC="$(CCS)" SCOTCHLIB=ptscotch						\
++					metis.h                                                                         \
+ 					libscotchmetis$(LIB)
+ 
+ ptscotch			:
+ 					$(MAKE) CFLAGS="$(CFLAGS) -DSCOTCH_PTSCOTCH" CC="$(CCP)" SCOTCHLIB=ptscotch	\
++					parmetis.h									\
+ 					libptscotchparmetis$(LIB)
+ 
+ install				:	scotch
+@@ -69,7 +71,7 @@ ptinstall			:	ptscotch
+ 					-$(CP) libptscotchparmetis$(LIB) $(libdir)
+ 
+ clean				:
+-					-$(RM) *~ *$(OBJ) lib*$(LIB)
++					-$(RM) *~ *$(OBJ) lib*$(LIB) metis.h parmetis.h
+ 
+ realclean			:	clean
+ 
+@@ -138,3 +140,10 @@ libscotchmetis$(LIB)		:	metis_graph_orde
+ 					metis_graph_part_f$(OBJ)
+ 					$(AR) $(ARFLAGS) $(@) $(^)
+ 					-$(RANLIB) $(@)
++metis.h				:	metis_skeleton.h			\
++					../libscotch/dummysizes
++					../libscotch/dummysizes metis_skeleton.h metis.h
++
++parmetis.h				:	parmetis_skeleton.h		\
++					../libscotch/dummysizes
++					../libscotch/dummysizes parmetis_skeleton.h parmetis.h
+--- A/src/libscotchmetis/metis.h	2012-09-13 17:43:52.000000000 +0200
++++ B/src/libscotchmetis/metis.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,97 +0,0 @@
+-/*********************************************************
+-**                                                      **
+-**  WARNING: THIS IS NOT THE ORIGINAL INCLUDE FILE OF   **
+-**  THE MeTiS SOFTWARE PACKAGE.                         **
+-**  This file is a compatibility include file provided  **
+-**  as part of the Scotch software distribution.        **
+-**  Preferably use the original MeTiS include file to   **
+-**  keep definitions of routines not overloaded by      **
+-**  the libScotchMeTiS library.                         **
+-**                                                      **
+-*********************************************************/
+-/* Copyright 2007,2010,2012 IPB, Universite de Bordeaux, INRIA & CNRS
+-**
+-** This file is part of the Scotch software package for static mapping,
+-** graph partitioning and sparse matrix ordering.
+-**
+-** This software is governed by the CeCILL-C license under French law
+-** and abiding by the rules of distribution of free software. You can
+-** use, modify and/or redistribute the software under the terms of the
+-** CeCILL-C license as circulated by CEA, CNRS and INRIA at the following
+-** URL: "http://www.cecill.info".
+-** 
+-** As a counterpart to the access to the source code and rights to copy,
+-** modify and redistribute granted by the license, users are provided
+-** only with a limited warranty and the software's author, the holder of
+-** the economic rights, and the successive licensors have only limited
+-** liability.
+-** 
+-** In this respect, the user's attention is drawn to the risks associated
+-** with loading, using, modifying and/or developing or reproducing the
+-** software by the user in light of its specific status of free software,
+-** that may mean that it is complicated to manipulate, and that also
+-** therefore means that it is reserved for developers and experienced
+-** professionals having in-depth computer knowledge. Users are therefore
+-** encouraged to load and test the software's suitability as regards
+-** their requirements in conditions enabling the security of their
+-** systems and/or data to be ensured and, more generally, to use and
+-** operate it in the same conditions as regards security.
+-** 
+-** The fact that you are presently reading this means that you have had
+-** knowledge of the CeCILL-C license and that you accept its terms.
+-*/
+-/************************************************************/
+-/**                                                        **/
+-/**   NAME       : metis.h                                 **/
+-/**                                                        **/
+-/**   AUTHOR     : Francois PELLEGRINI                     **/
+-/**                                                        **/
+-/**   FUNCTION   : Compatibility declaration file for the  **/
+-/**                MeTiS interface routines provided by    **/
+-/**                the Scotch project.                     **/
+-/**                                                        **/
+-/**   DATES      : # Version 5.0  : from : 08 sep 2006     **/
+-/**                                 to     07 jun 2007     **/
+-/**                # Version 5.1  : from : 30 jun 2010     **/
+-/**                                 to     30 jun 2010     **/
+-/**                # Version 6.0  : from : 13 sep 2012     **/
+-/**                                 to     13 sep 2012     **/
+-/**                                                        **/
+-/************************************************************/
+-
+-/*
+-**  The defines.
+-*/
+-
+-#ifdef SCOTCH_METIS_PREFIX
+-#define SCOTCH_METIS_PREFIXL        scotch_
+-#define SCOTCH_METIS_PREFIXU        SCOTCH_
+-#endif /* SCOTCH_METIS_PREFIX */
+-
+-#ifndef SCOTCH_METIS_PREFIXL
+-#define SCOTCH_METIS_PREFIXL
+-#endif /* SCOTCH_METIS_PREFIXL */
+-
+-#ifndef SCOTCH_METIS_PREFIXU
+-#define SCOTCH_METIS_PREFIXU
+-#endif /* SCOTCH_METIS_PREFIXU */
+-
+-#ifndef METISNAMEL
+-#define METISNAMEL(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXL),s)
+-#define METISNAMEU(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXU),s)
+-#define METISNAME2(p,s)             METISNAME4(p,s)
+-#define METISNAME3(s)               s
+-#define METISNAME4(p,s)             p##s
+-#endif /* METISNAMEL */
+-
+-/*
+-**  The function prototypes.
+-*/
+-
+-void                        METISNAMEU(METIS_EdgeND) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
+-void                        METISNAMEU(METIS_NodeND) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
+-void                        METISNAMEU(METIS_NodeWND) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
+-
+-void                        METISNAMEU(METIS_PartGraphKway) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
+-void                        METISNAMEU(METIS_PartGraphRecursive) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
+-void                        METISNAMEU(METIS_PartGraphVKway) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
+--- A/src/libscotchmetis/metis_skeleton.h	1970-01-01 01:00:00.000000000 +0100
++++ B/src/libscotchmetis/metis_skeleton.h	2015-08-25 13:27:07.224497875 +0200
+@@ -0,0 +1,103 @@
++/*********************************************************
++**                                                      **
++**  WARNING: THIS IS NOT THE ORIGINAL INCLUDE FILE OF   **
++**  THE MeTiS SOFTWARE PACKAGE.                         **
++**  This file is a compatibility include file provided  **
++**  as part of the Scotch software distribution.        **
++**  Preferably use the original MeTiS include file to   **
++**  keep definitions of routines not overloaded by      **
++**  the libScotchMeTiS library.                         **
++**                                                      **
++*********************************************************/
++/* Copyright 2007,2010,2012 IPB, Universite de Bordeaux, INRIA & CNRS
++**
++** This file is part of the Scotch software package for static mapping,
++** graph partitioning and sparse matrix ordering.
++**
++** This software is governed by the CeCILL-C license under French law
++** and abiding by the rules of distribution of free software. You can
++** use, modify and/or redistribute the software under the terms of the
++** CeCILL-C license as circulated by CEA, CNRS and INRIA at the following
++** URL: "http://www.cecill.info".
++** 
++** As a counterpart to the access to the source code and rights to copy,
++** modify and redistribute granted by the license, users are provided
++** only with a limited warranty and the software's author, the holder of
++** the economic rights, and the successive licensors have only limited
++** liability.
++** 
++** In this respect, the user's attention is drawn to the risks associated
++** with loading, using, modifying and/or developing or reproducing the
++** software by the user in light of its specific status of free software,
++** that may mean that it is complicated to manipulate, and that also
++** therefore means that it is reserved for developers and experienced
++** professionals having in-depth computer knowledge. Users are therefore
++** encouraged to load and test the software's suitability as regards
++** their requirements in conditions enabling the security of their
++** systems and/or data to be ensured and, more generally, to use and
++** operate it in the same conditions as regards security.
++** 
++** The fact that you are presently reading this means that you have had
++** knowledge of the CeCILL-C license and that you accept its terms.
++*/
++/************************************************************/
++/**                                                        **/
++/**   NAME       : metis.h                                 **/
++/**                                                        **/
++/**   AUTHOR     : Francois PELLEGRINI                     **/
++/**                                                        **/
++/**   FUNCTION   : Compatibility declaration file for the  **/
++/**                MeTiS interface routines provided by    **/
++/**                the Scotch project.                     **/
++/**                                                        **/
++/**   DATES      : # Version 5.0  : from : 08 sep 2006     **/
++/**                                 to     07 jun 2007     **/
++/**                # Version 5.1  : from : 30 jun 2010     **/
++/**                                 to     30 jun 2010     **/
++/**                # Version 6.0  : from : 13 sep 2012     **/
++/**                                 to     13 sep 2012     **/
++/**                                                        **/
++/************************************************************/
++
++#include<stdint.h>
++
++/*
++**  The defines.
++*/
++
++#ifdef SCOTCH_METIS_PREFIX
++#define SCOTCH_METIS_PREFIXL        scotch_
++#define SCOTCH_METIS_PREFIXU        SCOTCH_
++#endif /* SCOTCH_METIS_PREFIX */
++
++#ifndef SCOTCH_METIS_PREFIXL
++#define SCOTCH_METIS_PREFIXL
++#endif /* SCOTCH_METIS_PREFIXL */
++
++#ifndef SCOTCH_METIS_PREFIXU
++#define SCOTCH_METIS_PREFIXU
++#endif /* SCOTCH_METIS_PREFIXU */
++
++#ifndef METISNAMEL
++#define METISNAMEL(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXL),s)
++#define METISNAMEU(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXU),s)
++#define METISNAME2(p,s)             METISNAME4(p,s)
++#define METISNAME3(s)               s
++#define METISNAME4(p,s)             p##s
++#endif /* METISNAMEL */
++
++/*+ Integer type. +*/
++
++typedef DUMMYINT SCOTCH_Num;
++
++/*
++**  The function prototypes.
++*/
++
++void                        METISNAMEU(METIS_EdgeND) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
++void                        METISNAMEU(METIS_NodeND) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
++void                        METISNAMEU(METIS_NodeWND) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
++
++void                        METISNAMEU(METIS_PartGraphKway) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
++void                        METISNAMEU(METIS_PartGraphRecursive) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
++void                        METISNAMEU(METIS_PartGraphVKway) (const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const);
+--- A/src/libscotchmetis/parmetis.h	2012-09-13 17:41:21.000000000 +0200
++++ B/src/libscotchmetis/parmetis.h	1970-01-01 01:00:00.000000000 +0100
+@@ -1,100 +0,0 @@
+-/*********************************************************
+-**                                                      **
+-**  WARNING: THIS IS NOT THE ORIGINAL INCLUDE FILE OF   **
+-**  THE ParMeTiS SOFTWARE PACKAGE.                      **
+-**  This file is a compatibility include file provided  **
+-**  as part of the Scotch software distribution.        **
+-**  Preferably use the original ParMeTiS include file   **
+-**  to keep definitions of routines not overloaded by   **
+-**  the libPTScotchMeTiS library.                       **
+-**                                                      **
+-*********************************************************/
+-/* Copyright 2007,2008,2010,2012 IPB, Universite de Bordeaux, INRIA & CNRS
+-**
+-** This file is part of the Scotch software package for static mapping,
+-** graph partitioning and sparse matrix ordering.
+-**
+-** This software is governed by the CeCILL-C license under French law
+-** and abiding by the rules of distribution of free software. You can
+-** use, modify and/or redistribute the software under the terms of the
+-** CeCILL-C license as circulated by CEA, CNRS and INRIA at the following
+-** URL: "http://www.cecill.info".
+-** 
+-** As a counterpart to the access to the source code and rights to copy,
+-** modify and redistribute granted by the license, users are provided
+-** only with a limited warranty and the software's author, the holder of
+-** the economic rights, and the successive licensors have only limited
+-** liability.
+-** 
+-** In this respect, the user's attention is drawn to the risks associated
+-** with loading, using, modifying and/or developing or reproducing the
+-** software by the user in light of its specific status of free software,
+-** that may mean that it is complicated to manipulate, and that also
+-** therefore means that it is reserved for developers and experienced
+-** professionals having in-depth computer knowledge. Users are therefore
+-** encouraged to load and test the software's suitability as regards
+-** their requirements in conditions enabling the security of their
+-** systems and/or data to be ensured and, more generally, to use and
+-** operate it in the same conditions as regards security.
+-** 
+-** The fact that you are presently reading this means that you have had
+-** knowledge of the CeCILL-C license and that you accept its terms.
+-*/
+-/************************************************************/
+-/**                                                        **/
+-/**   NAME       : parmetis.h                              **/
+-/**                                                        **/
+-/**   AUTHOR     : Francois PELLEGRINI                     **/
+-/**                                                        **/
+-/**   FUNCTION   : Compatibility declaration file for the  **/
+-/**                MeTiS interface routines provided by    **/
+-/**                the Scotch project.                     **/
+-/**                                                        **/
+-/**   DATES      : # Version 5.0  : from : 17 oct 2007     **/
+-/**                                 to     18 oct 2007     **/
+-/**                # Version 5.1  : from : 19 jun 2008     **/
+-/**                                 to     30 jun 2010     **/
+-/**                # Version 6.0  : from : 13 sep 2012     **/
+-/**                                 to     13 sep 2012     **/
+-/**                                                        **/
+-/************************************************************/
+-
+-/*
+-**  The defines and includes.
+-*/
+-
+-#ifndef __parmetis_h__
+-#define __parmetis_h__
+-
+-#include <mpi.h>                                  /* Since ParMeTiS does it, do it too */
+-
+-#endif /* __parmetis_h__ */
+-
+-#ifdef SCOTCH_METIS_PREFIX
+-#define SCOTCH_METIS_PREFIXL        scotch_
+-#define SCOTCH_METIS_PREFIXU        SCOTCH_
+-#endif /* SCOTCH_METIS_PREFIX */
+-
+-#ifndef SCOTCH_METIS_PREFIXL
+-#define SCOTCH_METIS_PREFIXL
+-#endif /* SCOTCH_METIS_PREFIXL */
+-
+-#ifndef SCOTCH_METIS_PREFIXU
+-#define SCOTCH_METIS_PREFIXU
+-#endif /* SCOTCH_METIS_PREFIXU */
+-
+-#ifndef METISNAMEL
+-#define METISNAMEL(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXL),s)
+-#define METISNAMEU(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXU),s)
+-#define METISNAME2(p,s)             METISNAME4(p,s)
+-#define METISNAME3(s)               s
+-#define METISNAME4(p,s)             p##s
+-#endif /* METISNAMEL */
+-
+-/*
+-**  The function prototypes.
+-*/
+-
+-void                        METISNAMEU(ParMETIS_V3_NodeND) (const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, MPI_Comm * const);
+-void                        METISNAMEU(ParMETIS_V3_PartGeomKway) (const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const float * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const float * const, const float * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, MPI_Comm * const);
+-void                        METISNAMEU(ParMETIS_V3_PartKway) (const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const float * const, const float * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, MPI_Comm * const);
+--- A/src/libscotchmetis/parmetis_skeleton.h	1970-01-01 01:00:00.000000000 +0100
++++ B/src/libscotchmetis/parmetis_skeleton.h	2015-08-25 13:42:17.972454163 +0200
+@@ -0,0 +1,105 @@
++/*********************************************************
++**                                                      **
++**  WARNING: THIS IS NOT THE ORIGINAL INCLUDE FILE OF   **
++**  THE ParMeTiS SOFTWARE PACKAGE.                      **
++**  This file is a compatibility include file provided  **
++**  as part of the Scotch software distribution.        **
++**  Preferably use the original ParMeTiS include file   **
++**  to keep definitions of routines not overloaded by   **
++**  the libPTScotchMeTiS library.                       **
++**                                                      **
++*********************************************************/
++/* Copyright 2007,2008,2010,2012 IPB, Universite de Bordeaux, INRIA & CNRS
++**
++** This file is part of the Scotch software package for static mapping,
++** graph partitioning and sparse matrix ordering.
++**
++** This software is governed by the CeCILL-C license under French law
++** and abiding by the rules of distribution of free software. You can
++** use, modify and/or redistribute the software under the terms of the
++** CeCILL-C license as circulated by CEA, CNRS and INRIA at the following
++** URL: "http://www.cecill.info".
++** 
++** As a counterpart to the access to the source code and rights to copy,
++** modify and redistribute granted by the license, users are provided
++** only with a limited warranty and the software's author, the holder of
++** the economic rights, and the successive licensors have only limited
++** liability.
++** 
++** In this respect, the user's attention is drawn to the risks associated
++** with loading, using, modifying and/or developing or reproducing the
++** software by the user in light of its specific status of free software,
++** that may mean that it is complicated to manipulate, and that also
++** therefore means that it is reserved for developers and experienced
++** professionals having in-depth computer knowledge. Users are therefore
++** encouraged to load and test the software's suitability as regards
++** their requirements in conditions enabling the security of their
++** systems and/or data to be ensured and, more generally, to use and
++** operate it in the same conditions as regards security.
++** 
++** The fact that you are presently reading this means that you have had
++** knowledge of the CeCILL-C license and that you accept its terms.
++*/
++/************************************************************/
++/**                                                        **/
++/**   NAME       : parmetis.h                              **/
++/**                                                        **/
++/**   AUTHOR     : Francois PELLEGRINI                     **/
++/**                                                        **/
++/**   FUNCTION   : Compatibility declaration file for the  **/
++/**                MeTiS interface routines provided by    **/
++/**                the Scotch project.                     **/
++/**                                                        **/
++/**   DATES      : # Version 5.0  : from : 17 oct 2007     **/
++/**                                 to     18 oct 2007     **/
++/**                # Version 5.1  : from : 19 jun 2008     **/
++/**                                 to     30 jun 2010     **/
++/**                # Version 6.0  : from : 13 sep 2012     **/
++/**                                 to     13 sep 2012     **/
++/**                                                        **/
++/************************************************************/
++
++/*
++**  The defines and includes.
++*/
++
++#ifndef __parmetis_h__
++#define __parmetis_h__
++
++#include<stdint.h>
++#include <mpi.h>                                  /* Since ParMeTiS does it, do it too */
++
++#endif /* __parmetis_h__ */
++
++#ifdef SCOTCH_METIS_PREFIX
++#define SCOTCH_METIS_PREFIXL        scotch_
++#define SCOTCH_METIS_PREFIXU        SCOTCH_
++#endif /* SCOTCH_METIS_PREFIX */
++
++#ifndef SCOTCH_METIS_PREFIXL
++#define SCOTCH_METIS_PREFIXL
++#endif /* SCOTCH_METIS_PREFIXL */
++
++#ifndef SCOTCH_METIS_PREFIXU
++#define SCOTCH_METIS_PREFIXU
++#endif /* SCOTCH_METIS_PREFIXU */
++
++#ifndef METISNAMEL
++#define METISNAMEL(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXL),s)
++#define METISNAMEU(s)               METISNAME2(METISNAME3(SCOTCH_METIS_PREFIXU),s)
++#define METISNAME2(p,s)             METISNAME4(p,s)
++#define METISNAME3(s)               s
++#define METISNAME4(p,s)             p##s
++#endif /* METISNAMEL */
++
++/*+ Integer type. +*/
++
++typedef DUMMYINT SCOTCH_Num;
++
++/*
++**  The function prototypes.
++*/
++
++void                        METISNAMEU(ParMETIS_V3_NodeND) (const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, MPI_Comm * const);
++void                        METISNAMEU(ParMETIS_V3_PartGeomKway) (const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const float * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const float * const, const float * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, MPI_Comm * const);
++void                        METISNAMEU(ParMETIS_V3_PartKway) (const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const SCOTCH_Num * const, const float * const, const float * const, const SCOTCH_Num * const, SCOTCH_Num * const, SCOTCH_Num * const, MPI_Comm * const);
+--- A/src/Makefile	2014-10-02 17:31:36.000000000 +0200
++++ B/src/Makefile	2015-08-25 13:00:50.288573562 +0200
+@@ -115,6 +115,7 @@ install				:	required	$(bindir)	$(includ
+ 					-$(CP) -f ../bin/[agm]*$(EXE) $(bindir)
+ 					-$(CP) -f ../bin/d[agm]*$(EXE) $(bindir)
+ 					-$(CP) -f ../include/*scotch*.h $(includedir)
++					-$(CP) -f ../include/*metis*.h $(includedir)
+ 					-$(CP) -f ../lib/*scotch*$(LIB) $(libdir)
+ 					-$(CP) -Rf ../man/* $(mandir)
+ 
+--- A/src/Makefile~	1970-01-01 01:00:00.000000000 +0100
++++ B/src/Makefile~	2014-10-02 17:31:36.000000000 +0200
+@@ -0,0 +1,134 @@
++## Copyright 2004,2007,2008,2010-2012,2014 IPB, Universite de Bordeaux, INRIA & CNRS
++##
++## This file is part of the Scotch software package for static mapping,
++## graph partitioning and sparse matrix ordering.
++##
++## This software is governed by the CeCILL-C license under French law
++## and abiding by the rules of distribution of free software. You can
++## use, modify and/or redistribute the software under the terms of the
++## CeCILL-C license as circulated by CEA, CNRS and INRIA at the following
++## URL: "http://www.cecill.info".
++## 
++## As a counterpart to the access to the source code and rights to copy,
++## modify and redistribute granted by the license, users are provided
++## only with a limited warranty and the software's author, the holder of
++## the economic rights, and the successive licensors have only limited
++## liability.
++## 
++## In this respect, the user's attention is drawn to the risks associated
++## with loading, using, modifying and/or developing or reproducing the
++## software by the user in light of its specific status of free software,
++## that may mean that it is complicated to manipulate, and that also
++## therefore means that it is reserved for developers and experienced
++## professionals having in-depth computer knowledge. Users are therefore
++## encouraged to load and test the software's suitability as regards
++## their requirements in conditions enabling the security of their
++## systems and/or data to be ensured and, more generally, to use and
++## operate it in the same conditions as regards security.
++## 
++## The fact that you are presently reading this means that you have had
++## knowledge of the CeCILL-C license and that you accept its terms.
++##
++
++VERSION	= 6
++RELEASE = 0
++PATCHLEVEL = 4
++
++.PHONY				:	clean	default	install	ptscotch	realclean	required	scotch
++
++default				:	scotch
++
++required			:	Makefile.inc	../bin	../include	../lib
++
++Makefile.inc			:
++					@echo "#####################################################################"
++			        	@echo "BEFORE COMPILING Scotch OR PT-Scotch, YOU SHOULD HAVE AN APPROPRIATE"
++					@echo "Makefile.inc FILE IN THIS DIRECTORY. PLEASE LOOK INTO DIRECTORY"
++	        			@echo " ./Make.inc FOR AN EXISTING Makefile.inc FILE THAT FITS YOUR NEED, OR"
++		        		@echo "USE THEM AS MODELS IN CASE YOU NEED TO BUILD A NEW ONE FOR YOUR"
++		        		@echo "PARTICULAR PLATFORM."
++			        	@echo "#####################################################################"
++			        	@echo "Then, type \"make scotch\" (default) for the sequential library"
++			        	@echo "and software, or \"make ptscotch\" for the parallel library and"
++			        	@echo "software."
++					@exit 1
++
++include Makefile.inc
++
++prefix		?= /usr/local
++bindir		?= $(prefix)/bin
++includedir	?= $(prefix)/include
++libdir		?= $(prefix)/lib
++datarootdir	?= $(prefix)/share
++mandir		?= $(datarootdir)/man
++
++../bin				:
++					-$(MKDIR) ../bin
++
++../include			:
++					-$(MKDIR) ../include
++
++../lib				:
++					-$(MKDIR) ../lib
++
++$(bindir)			:
++					-$(MKDIR) $(bindir)
++
++$(datarootdir)			:
++					-$(MKDIR) $(datarootdir)
++
++$(includedir)			:
++					-$(MKDIR) $(includedir)
++
++$(libdir)			:
++					-$(MKDIR) $(libdir)
++
++$(mandir)			:	$(datarootdir)
++					-$(MKDIR) $(mandir)
++
++$(mandir)/man1			:	$(mandir)
++					-$(MKDIR) $(mandir)/man1
++
++scotch				:	required
++					(cd libscotch ;      $(MAKE) VERSION=$(VERSION) RELEASE=$(RELEASE) PATCHLEVEL=$(PATCHLEVEL) scotch && $(MAKE) install)
++					(cd scotch ;         $(MAKE) VERSION=$(VERSION) RELEASE=$(RELEASE) PATCHLEVEL=$(PATCHLEVEL) scotch && $(MAKE) install)
++					(cd libscotchmetis ; $(MAKE)                                                                scotch && $(MAKE) install)
++
++ptscotch			:	required
++					(cd libscotch ;      $(MAKE) VERSION=$(VERSION) RELEASE=$(RELEASE) PATCHLEVEL=$(PATCHLEVEL) ptscotch && $(MAKE) ptinstall)
++					(cd scotch ;         $(MAKE) VERSION=$(VERSION) RELEASE=$(RELEASE) PATCHLEVEL=$(PATCHLEVEL) ptscotch && $(MAKE) ptinstall)
++					(cd libscotchmetis ; $(MAKE)                                                                ptscotch && $(MAKE) ptinstall)
++
++check				:	scotch
++					(cd check ; $(MAKE) check)
++
++ptcheck				:	ptscotch
++					(cd check ; $(MAKE) ptcheck)
++
++esmumps				:	scotch
++					(cd esmumps ; $(MAKE) scotch && $(MAKE) install)
++
++ptesmumps			:	ptscotch
++					(cd esmumps ; $(MAKE) ptscotch && $(MAKE) ptinstall)
++
++install				:	required	$(bindir)	$(includedir)	$(libdir)	$(mandir)/man1
++					-$(CP) -f ../bin/[agm]*$(EXE) $(bindir)
++					-$(CP) -f ../bin/d[agm]*$(EXE) $(bindir)
++					-$(CP) -f ../include/*scotch*.h $(includedir)
++					-$(CP) -f ../lib/*scotch*$(LIB) $(libdir)
++					-$(CP) -Rf ../man/* $(mandir)
++
++clean				:	required
++					(cd libscotch ;      $(MAKE) clean)
++					(cd scotch ;         $(MAKE) clean)
++					(cd libscotchmetis ; $(MAKE) clean)
++					(cd check ;          $(MAKE) clean)
++					(cd esmumps ;        $(MAKE) clean)
++
++realclean			:	required
++					(cd libscotch ;      $(MAKE) realclean)
++					(cd scotch ;         $(MAKE) realclean)
++					(cd libscotchmetis ; $(MAKE) realclean)
++					(cd check ;          $(MAKE) realclean)
++					(cd esmumps ;        $(MAKE) realclean)
++					-$(RM) ../bin/* ../include/* ../lib/*
+--- A/src/Make.inc/Makefile.inc.x86-64_pc_linux2~	1970-01-01 01:00:00.000000000 +0100
++++ B/src/Make.inc/Makefile.inc.x86-64_pc_linux2~	2015-08-25 13:09:33.984548426 +0200
+@@ -0,0 +1,21 @@
++EXE		=
++LIB		= .a
++OBJ		= .o
++
++MAKE		= make
++AR		= ar
++ARFLAGS		= -ruv
++CAT		= cat
++CCS		= gcc
++CCP		= mpicc
++CCD		= gcc
++CFLAGS		= -O3 -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_PTHREAD -DCOMMON_RANDOM_FIXED_SEED -DSCOTCH_RENAME -DSCOTCH_PTHREAD -Drestrict=__restrict -DIDXSIZE64 -DINT=int64_t
++CLIBFLAGS	=
++LDFLAGS		= -lz -lm -lrt -pthread
++CP		= cp
++LEX		= flex -Pscotchyy -olex.yy.c
++LN		= ln
++MKDIR		= mkdir
++MV		= mv
++RANLIB		= ranlib
++YACC		= bison -pscotchyy -y -b y

--- a/scripts/spack_packages/packages/scotch/nonthreaded-6.0.4.patch
+++ b/scripts/spack_packages/packages/scotch/nonthreaded-6.0.4.patch
@@ -1,0 +1,11 @@
+--- scotch_6.0.4.orig/src/libscotch/common.h	2015-03-01 10:14:02.000000000 +0100
++++ scotch_6.0.4/src/libscotch/common.h	2017-03-27 13:07:18.644221999 +0200
+@@ -306,6 +306,8 @@
+   ThreadLaunchStartFunc     stafptr;              /*+ Pointer to start routine +*/
+   ThreadLaunchJoinFunc      joifptr;              /*+ Pointer to join routine  +*/
+   ThreadBarrier             barrdat;              /*+ Barrier data structure   +*/
++#else
++  int                       thrdnbr;    /* dummy for non-threaded */
+ #endif /* ((defined COMMON_PTHREAD) || (defined SCOTCH_PTHREAD)) */
+ } ThreadGroupHeader;
+ 

--- a/scripts/spack_packages/packages/scotch/package.py
+++ b/scripts/spack_packages/packages/scotch/package.py
@@ -1,0 +1,315 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.build_systems import cmake, makefile
+from spack.build_systems.cmake import CMakePackage
+from spack.build_systems.makefile import MakefilePackage
+
+from spack.package import *
+
+
+class Scotch(CMakePackage, MakefilePackage):
+    """Scotch is a software package for graph and mesh/hypergraph
+    partitioning, graph clustering, and sparse matrix ordering.
+    """
+
+    homepage = "https://gitlab.inria.fr/scotch/scotch"
+    git = "https://gitlab.inria.fr/scotch/scotch.git"
+    url = "https://gitlab.inria.fr/scotch/scotch/-/archive/v7.0.1/scotch-v7.0.1.tar.gz"
+    list_url = "https://gforge.inria.fr/frs/?group_id=248"
+
+    maintainers("pghysels")
+
+    version("7.0.7", sha256="02084471d2ca525f8a59b4bb8c607eb5cca452d6a38cf5c89f5f92f7edc1a5b5")
+    version("7.0.6", sha256="b44acd0d2f53de4b578fa3a88944cccc45c4d2961cd8cefa9b9a1d5431de8e2b")
+    version("7.0.4", sha256="8ef4719d6a3356e9c4ca7fefd7e2ac40deb69779a5c116f44da75d13b3d2c2c3")
+    version("7.0.3", sha256="5b5351f0ffd6fcae9ae7eafeccaa5a25602845b9ffd1afb104db932dd4d4f3c5")
+    version("7.0.1", sha256="0618e9bc33c02172ea7351600fce4fccd32fe00b3359c4aabb5e415f17c06fed")
+    version("6.1.3", sha256="4e54f056199e6c23d46581d448fcfe2285987e5554a0aa527f7931684ef2809e")
+    version("6.1.2", sha256="9c2c75c75f716914a2bd1c15dffac0e29a2f8069b2df1ad2b6207c984b699450")
+    version("6.1.1", sha256="14daf151399fc67f83fd3ff2933854f5e8d2207c7d35dd66a05660bf0bbd583c")
+    version("6.1.0", sha256="4fe537f608f0fe39ec78807f90203f9cca1181deb16bfa93b7d4cd440e01bbd1")
+    version("6.0.10", sha256="e5542b6102b5616f0f5c6619e3e9d52f9d0e48cb991e9b30670f598deeac0553")
+    version("6.0.9", sha256="b9bc86c50b65781eb416663e938d57555373c2517ea8b9acf680fd3acde0cb0c")
+    version("6.0.8", sha256="9457c1e7c30f073686cc217345b5a96af4166d6abbf148af84cdbab4e144b299")
+    version("6.0.6", sha256="e932b4c04636fcf5d21b9a76376868de052c9b000bdaf96f8967dcec61bdaa10")
+    version("6.0.5a", sha256="5b21b95e33acd5409d682fa7253cefbdffa8db82875549476c006d8cbe7c556f")
+    version("6.0.4", sha256="f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7")
+    version("6.0.3", sha256="6461cc9f28319a9dbe6cc10e28c0cbe90b4b25e205723c3edcde9a3ff974d6d8")
+    version("6.0.0", sha256="8206127d038bda868dda5c5a7f60ef8224f2e368298fbb01bf13fa250e378dd4")
+    version("5.1.10b", sha256="54c9e7fafefd49d8b2017d179d4f11a655abe10365961583baaddc4eeb6a9add")
+
+    build_system(conditional("cmake", when="@7:"), "makefile", default="cmake")
+    variant("threads", default=True, description="use POSIX Pthreads within Scotch and PT-Scotch")
+    variant(
+        "mpi_thread",
+        default=False,
+        description="use multi-threaded algorithms in conjunction with MPI",
+    )
+    variant("mpi", default=True, description="Compile parallel libraries")
+    variant("compression", default=True, description="May use compressed files")
+    variant("esmumps", default=False, description="Compile esmumps (needed by mumps)")
+    variant("shared", default=True, description="Build a shared version of the library")
+    variant(
+        "metis", default=False, description="Expose vendored METIS/ParMETIS libraries and wrappers"
+    )
+    variant("int64", default=False, description="Use int64_t for SCOTCH_Num typedef")
+    variant("noarch", default=False, description="Unset SPACK_TARGET_ARGS")
+    variant(
+        "link_error_lib",
+        default=False,
+        when="@7.0.1",
+        description="Link error handling library to libscotch/libptscotch",
+    )
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+    depends_on("fortran", type="build")
+
+    # Does not build with flex 2.6.[23]
+    depends_on("flex@:2.6.1,2.6.4:", type="build")
+    depends_on("bison@3.4:", type="build")
+    depends_on("mpi", when="+mpi")
+    depends_on("zlib-api", when="+compression")
+
+    # Version-specific patches
+    patch("nonthreaded-6.0.4.patch", when="@6.0.4")
+    patch("esmumps-ldflags-6.0.4.patch", when="@6.0.4")
+    patch("metis-headers-6.0.4.patch", when="@6.0.4")
+
+    patch("libscotchmetis-return-6.0.5a.patch", when="@6.0.5a")
+    patch("libscotch-scotcherr-link-7.0.1.patch", when="@7.0.1 +link_error_lib")
+
+    # Avoid OpenMPI segfaults by using MPI_Comm_F2C for parmetis communicator
+    patch("parmetis-mpi.patch", when="@6.1.1:7.0.3 +metis ^openmpi")
+
+    # Vendored dependency of METIS/ParMETIS conflicts with standard
+    # installations
+    conflicts("metis", when="+metis")
+    conflicts("parmetis", when="+metis")
+
+    parallel = False
+
+    # NOTE: Versions of Scotch up to version 6.0.0 don't include support for
+    # building with 'esmumps' in their default packages.  In order to enable
+    # support for this feature, we must grab the 'esmumps' enabled archives
+    # from the Scotch hosting site.  These alternative archives include a
+    # superset of the behavior in their default counterparts, so we choose to
+    # always grab these versions for older Scotch versions for simplicity.
+    @when("@:6.0.0")
+    def url_for_version(self, version):
+        url = "https://gforge.inria.fr/frs/download.php/latestfile/298/scotch_{0}_esmumps.tar.gz"
+        return url.format(version)
+
+    @property
+    def libs(self):
+        shared = "+shared" in self.spec
+        libraries = ["libscotch", "libscotcherr"]
+        zlibs = []
+
+        if "+mpi" in self.spec:
+            libraries = ["libptscotch", "libptscotcherr"] + libraries
+
+        if "+esmumps" in self.spec:
+            if "~mpi" in self.spec or self.spec.version >= Version("7.0.0"):
+                libraries = ["libesmumps"] + libraries
+            else:
+                libraries = ["libptesmumps"] + libraries
+
+        scotchlibs = find_libraries(libraries, root=self.prefix, recursive=True, shared=shared)
+        if "+compression" in self.spec:
+            zlibs = self.spec["zlib-api"].libs
+
+        return scotchlibs + zlibs
+
+
+class CMakeBuilder(cmake.CMakeBuilder):
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_LIBSCOTCHMETIS", "metis"),
+            self.define_from_variant("INSTALL_METIS_HEADERS", "metis"),
+            self.define_from_variant("BUILD_LIBESMUMPS", "esmumps"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("BUILD_PTSCOTCH", "mpi"),
+            self.define_from_variant("THREADS", "threads"),
+            self.define_from_variant("MPI_THREAD_MULTIPLE", "mpi_thread"),
+            self.define("SCOTCH_RANDOM", "FIXED_SEED"),
+        ]
+
+        if self.pkg.version > Version("7.0.4"):
+            args.append(self.define("ENABLE_TESTS", self.pkg.run_tests))
+
+        if "+int64" in self.spec:
+            args.append("-DINTSIZE=64")
+        elif self.is_64bit():
+            c_flags = []
+            c_flags.append("-DIDXSIZE64")
+            c_flags.append("-DINTSIZE32")
+            args.append(self.define("CMAKE_C_FLAGS", " ".join(c_flags)))
+
+        return args
+
+    def is_64bit(self):
+        return "64" in str(self.pkg.spec.target.family)
+
+    @when("+noarch")
+    def setup_build_environment(self, env) -> None:
+        env.unset("SPACK_TARGET_ARGS")
+
+
+class MakefileBuilder(makefile.MakefileBuilder):
+    build_directory = "src"
+
+    def edit(self, pkg, spec, prefix):
+        makefile_inc = []
+        cflags = ["-O3", "-DCOMMON_RANDOM_FIXED_SEED", "-DSCOTCH_DETERMINISTIC", "-DSCOTCH_RENAME"]
+
+        # SCOTCH_Num typedef: size of integers in arguments
+        # SCOTCH_Idx typedef: indices for addressing
+        if "+int64" in self.spec:
+            cflags.append("-DINTSIZE64")
+            cflags.append("-DIDXSIZE64")
+        elif self.is_64bit():
+            cflags.append("-DINTSIZE32")
+            cflags.append("-DIDXSIZE64")
+        else:
+            cflags.append("-DINTSIZE32")
+            cflags.append("-DIDXSIZE32")
+
+        if self.spec.satisfies("platform=darwin"):
+            cflags.extend(["-Drestrict=__restrict"])
+
+        if "~metis" in self.spec:
+            # Scotch requires METIS to build, but includes its own patched,
+            # vendored dependency. Prefix its internal symbols so they won't
+            # conflict with another installation.
+            cflags.append("-DSCOTCH_METIS_PREFIX")
+
+        if self.spec.satisfies("+mpi"):
+            cflags.append("-DSCOTCH_PTHREAD_MPI")
+            if self.spec.satisfies("@7.0:"):
+                cflags.append("-DSCOTCH_MPI_ASYNC_COLL")
+
+        if self.spec.satisfies("platform=linux"):
+            cflags.append("-DCOMMON_PTHREAD_AFFINITY_LINUX")
+
+        # Library Build Type #
+        if "+shared" in self.spec:
+            if self.spec.satisfies("platform=darwin"):
+                makefile_inc.extend(
+                    [
+                        "LIB       = .dylib",
+                        "CLIBFLAGS = -dynamiclib {0}".format(pkg.compiler.cc_pic_flag),
+                        "RANLIB    = echo",
+                        "AR        = $(CC)",
+                        (
+                            "ARFLAGS = -dynamiclib $(LDFLAGS) "
+                            "-Wl,-install_name -Wl,%s/$(notdir $@) "
+                            "-undefined dynamic_lookup -o "
+                        )
+                        % prefix.lib,
+                    ]
+                )
+            else:
+                makefile_inc.extend(
+                    [
+                        "LIB       = .so",
+                        "CLIBFLAGS = -shared {0}".format(pkg.compiler.cc_pic_flag),
+                        "RANLIB    = echo",
+                        "AR        = $(CC)",
+                        "ARFLAGS   = -shared $(LDFLAGS) -o",
+                    ]
+                )
+            cflags.append(pkg.compiler.cc_pic_flag)
+        else:
+            makefile_inc.extend(
+                [
+                    "LIB       = .a",
+                    "CLIBFLAGS = ",
+                    "RANLIB    = ranlib",
+                    "AR        = ar",
+                    "ARFLAGS   = -ruv ",
+                ]
+            )
+
+        # Compiler-Specific Options #
+
+        if pkg.compiler.name == "gcc":
+            cflags.append("-Drestrict=__restrict")
+        elif pkg.compiler.name == "intel":
+            cflags.append("-Drestrict=")
+
+        mpicc_path = self.spec["mpi"].mpicc if "+mpi" in self.spec else "mpicc"
+        makefile_inc.append("CCS       = $(CC)")
+        makefile_inc.append("CCP       = %s" % mpicc_path)
+        makefile_inc.append("CCD       = $(CCS)")
+
+        # Extra Features #
+
+        ldflags = []
+
+        if "+compression" in self.spec:
+            cflags.append("-DCOMMON_FILE_COMPRESS_GZ")
+            ldflags.append(" {0} ".format(self.spec["zlib-api"].libs.joined()))
+
+        cflags.append("-DCOMMON_PTHREAD")
+
+        # NOTE: bg-q platform needs -lpthread (and not -pthread)
+        # otherwise we get illegal instruction error during runtime
+        if self.spec.satisfies("platform=darwin"):
+            cflags.append("-DCOMMON_PTHREAD_BARRIER")
+            ldflags.append("-lm -pthread")
+        else:
+            ldflags.append("-lm -lrt -pthread")
+
+        makefile_inc.append("LDFLAGS   = %s" % " ".join(ldflags))
+
+        # General Features #
+
+        flex_path = self.spec["flex"].command.path
+        bison_path = self.spec["bison"].command.path
+        makefile_inc.extend(
+            [
+                "EXE       =",
+                "OBJ       = .o",
+                "MAKE      = make",
+                "CAT       = cat",
+                "LN        = ln",
+                "MKDIR     = mkdir",
+                "MV        = mv",
+                "CP        = cp",
+                "CFLAGS    = %s" % " ".join(cflags),
+                "prefix    = %s" % self.prefix,
+            ]
+        )
+        if self.spec.satisfies("@7.0:"):
+            makefile_inc.extend(["FLEX       = %s" % flex_path, "BISON      = %s" % bison_path])
+        else:
+            makefile_inc.extend(
+                [
+                    "LEX       = %s -Pscotchyy -olex.yy.c" % flex_path,
+                    "YACC      = %s -pscotchyy -y -b y" % bison_path,
+                ]
+            )
+
+        with working_dir("src"):
+            with open("Makefile.inc", "w") as fh:
+                fh.write("\n".join(makefile_inc))
+
+    def is_64bit(self):
+        return "64" in str(self.pkg.spec.target.family)
+
+    @property
+    def build_targets(self):
+        targets = ["scotch"]
+        if "+mpi" in self.spec:
+            targets.append("ptscotch")
+
+        if self.spec.version >= Version("6.0.0"):
+            if "+esmumps" in self.spec:
+                targets.append("esmumps")
+                if "+mpi" in self.spec:
+                    targets.append("ptesmumps")
+        return targets

--- a/scripts/spack_packages/packages/scotch/parmetis-mpi.patch
+++ b/scripts/spack_packages/packages/scotch/parmetis-mpi.patch
@@ -1,0 +1,127 @@
+diff --git a/src/libscotchmetis/parmetis_dgraph_order_f.c b/src/libscotchmetis/parmetis_dgraph_order_f.c
+index 44c2ede..549a834 100644
+--- a/src/libscotchmetis/parmetis_dgraph_order_f.c
++++ b/src/libscotchmetis/parmetis_dgraph_order_f.c
+@@ -46,7 +46,7 @@
+ /**                # Version 6.0  : from : 13 sep 2012     **/
+ /**                                 to   : 18 may 2019     **/
+ /**                # Version 7.0  : from : 21 jan 2023     **/
+-/**                                 to   : 21 jan 2023     **/
++/**                                 to   : 30 jun 2023     **/
+ /**                                                        **/
+ /************************************************************/
+ 
+@@ -76,11 +76,14 @@ const SCOTCH_Num * const    numflag,                    \
+ const SCOTCH_Num * const    options,                    \
+ SCOTCH_Num * const          order,                      \
+ SCOTCH_Num * const          sizes,                      \
+-MPI_Comm * const            commptr,                    \
++const MPI_Fint * const      commptr,                    \
+ int * const                 revaptr),                   \
+ (vtxdist, xadj, adjncy, numflag, options, order, sizes, commptr, revaptr))
+ {
+-  *revaptr = SCOTCH_ParMETIS_V3_NodeND (vtxdist, xadj, adjncy, numflag, options, order, sizes, commptr);
++  MPI_Comm            commdat;
++
++  commdat = MPI_Comm_f2c (*commptr);
++  *revaptr = SCOTCH_ParMETIS_V3_NodeND (vtxdist, xadj, adjncy, numflag, options, order, sizes, &commdat);
+ }
+ 
+ /*******************/
+@@ -101,10 +104,13 @@ const SCOTCH_Num * const    numflag,                                \
+ const SCOTCH_Num * const    options,                                \
+ SCOTCH_Num * const          order,                                  \
+ SCOTCH_Num * const          sizes,                                  \
+-MPI_Comm * const            commptr),                               \
++const MPI_Fint * const      commptr),                               \
+ (vtxdist, xadj, adjncy, numflag, options, order, sizes, commptr))
+ {
+-  METISNAMEU (ParMETIS_V3_NodeND) (vtxdist, xadj, adjncy, numflag, options, order, sizes, commptr);
++  MPI_Comm            commdat;
++
++  commdat = MPI_Comm_f2c (*commptr);
++  METISNAMEU (ParMETIS_V3_NodeND) (vtxdist, xadj, adjncy, numflag, options, order, sizes, &commdat);
+ }
+ 
+ #endif /* SCOTCH_METIS_PREFIX */
+diff --git a/src/libscotchmetis/parmetis_dgraph_part_f.c b/src/libscotchmetis/parmetis_dgraph_part_f.c
+index 2b76818..3bf66af 100644
+--- a/src/libscotchmetis/parmetis_dgraph_part_f.c
++++ b/src/libscotchmetis/parmetis_dgraph_part_f.c
+@@ -44,7 +44,7 @@
+ /**                # Version 6.0  : from : 13 sep 2012     **/
+ /**                                 to   : 18 may 2019     **/
+ /**                # Version 7.0  : from : 21 jan 2023     **/
+-/**                                 to   : 21 jan 2023     **/
++/**                                 to   : 30 jun 2023     **/
+ /**                                                        **/
+ /************************************************************/
+ 
+@@ -81,12 +81,15 @@ const float * const         ubvec,                          \
+ const SCOTCH_Num * const    options,                        \
+ SCOTCH_Num * const          edgecut,                        \
+ SCOTCH_Num * const          part,                           \
+-MPI_Comm * const            commptr,                        \
++const MPI_Fint * const      commptr,                        \
+ int * const                 revaptr),                       \
+ (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr, revaptr))
+ {
++  MPI_Comm            commdat;
++
++  commdat = MPI_Comm_f2c (*commptr);
+   *revaptr = SCOTCH_ParMETIS_V3_PartKway (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag,
+-                                          ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr);
++                                          ncon, nparts, tpwgts, ubvec, options, edgecut, part, &commdat);
+ }
+ 
+ /*
+@@ -111,12 +114,15 @@ const float * const         ubvec,                                  \
+ const SCOTCH_Num * const    options,                                \
+ SCOTCH_Num * const          edgecut,                                \
+ SCOTCH_Num * const          part,                                   \
+-MPI_Comm * const            commptr,                                \
++const MPI_Fint * const      commptr,                                \
+ int * const                 revaptr),                               \
+ (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ndims, xyz, ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr, revaptr))
+ {
++  MPI_Comm            commdat;
++
++  commdat = MPI_Comm_f2c (*commptr);
+   *revaptr = SCOTCH_ParMETIS_V3_PartGeomKway (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag,
+-                                              ndims, xyz, ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr);
++                                              ndims, xyz, ncon, nparts, tpwgts, ubvec, options, edgecut, part, &commdat);
+ }
+ 
+ /*******************/
+@@ -144,10 +150,13 @@ const float * const         ubvec,                                      \
+ const SCOTCH_Num * const    options,                                    \
+ SCOTCH_Num * const          edgecut,                                    \
+ SCOTCH_Num * const          part,                                       \
+-MPI_Comm * const            commptr),                                   \
++const MPI_Fint * const      commptr),                                   \
+ (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr))
+ {
+-  METISNAMEU (ParMETIS_V3_PartKway) (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr);
++  MPI_Comm            commdat;
++
++  commdat = MPI_Comm_f2c (*commptr);
++  METISNAMEU (ParMETIS_V3_PartKway) (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ncon, nparts, tpwgts, ubvec, options, edgecut, part, &commdat);
+ }
+ 
+ /*
+@@ -172,10 +181,13 @@ const float * const         ubvec,
+ const SCOTCH_Num * const    options,                                            \
+ SCOTCH_Num * const          edgecut,                                            \
+ SCOTCH_Num * const          part,                                               \
+-MPI_Comm * const            commptr),                                           \
++const MPI_Fint * const      commptr),                                           \
+ (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ndims, xyz, ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr))
+ {
+-  METISNAMEU (ParMETIS_V3_PartGeomKway) (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ndims, xyz, ncon, nparts, tpwgts, ubvec, options, edgecut, part, commptr);
++  MPI_Comm            commdat;
++
++  commdat = MPI_Comm_f2c (*commptr);
++  METISNAMEU (ParMETIS_V3_PartGeomKway) (vtxdist, xadj, adjncy, vwgt, adjwgt, wgtflag, numflag, ndims, xyz, ncon, nparts, tpwgts, ubvec, options, edgecut, part, &commdat);
+ }
+ 
+ #endif /* SCOTCH_METIS_PREFIX */

--- a/tplMirror/scotch-v7.0.3.tar.gz
+++ b/tplMirror/scotch-v7.0.3.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b5351f0ffd6fcae9ae7eafeccaa5a25602845b9ffd1afb104db932dd4d4f3c5
-size 7042800

--- a/tplMirror/scotch-v7.0.7.tar.gz
+++ b/tplMirror/scotch-v7.0.7.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02084471d2ca525f8a59b4bb8c607eb5cca452d6a38cf5c89f5f92f7edc1a5b5
+size 7708868


### PR DESCRIPTION
Move Scotch from Makefile to CMake build and update version. 

Fixes some link errors that result from `libptscotch`'s dependence on `libmpi` not being known to GEOS' CMake when `scotch` target is imported from a Makefile build, resulting in wrong order of dependencies on link line. (Reproducible on a branch I'm working on, not on `develop`).

For spack build, this required backporting Scotch package from spack ToT. The backport should be removed when we update our spack version.

Drive-by fixes for spack build:
  * PETSc was pinned to an outdated version (apparently no one has built with `+petsc` in a long time)
  * Adiak info was incorrect (wrong case in `ADIAK_DIR` and invalid path) in the output host-config, resulting in all GEOS builds excluding Adiak.