### PR TITLE
Improve uberenv build scripts

### DIFF
--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -49,6 +49,7 @@ if [ $? -eq 0 ]; then
   rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/.spack-db"
   rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/misc_cache"
   rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/spack"
+  rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/builtin_spack_packages_repo"
   rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/build_stage"
 
   # --- 3. Conditionally Set Permissions ---

--- a/scripts/setupLC-TPL-uberenv-helper.bash
+++ b/scripts/setupLC-TPL-uberenv-helper.bash
@@ -1,56 +1,75 @@
 #!/bin/bash
 
 ## Builds the TPLs for a specific system and host config.
-## Usage ./setupLC-TPL-uberenv-helper.bash pathToInstallDirectory machine compiler spackSpecToBuild commandToGetANode
+## Usage ./setupLC-TPL-uberenv-helper.bash <InstallDir> <Machine> <Compiler> <SpackSpec> <AllocCmd> [ExtraArgs...]
+
+# --- 1. Initialize Control Variable ---
+# By default, we will set permissions.
+SET_PERMISSIONS=true
+
+# --- Argument Parsing ---
 INSTALL_DIR=$1
 MACHINE=$2
 COMPILER=$3
 SPEC=\"${4}\"
 GET_A_NODE=$5
 
-## Eat up the command line arguments so the rest can be forwarded to config-build.
-shift
-shift
-shift
-shift
-shift
+# Eat up the primary arguments; the rest in $@ are forwarded.
+shift 5
 
+# --- 2. Check for the --no-permissions Flag ---
+# Loop through the forwarded arguments to find our flag.
+for arg in "$@"; do
+  if [[ "$arg" == "--no-permissions" ]]; then
+    SET_PERMISSIONS=false
+    echo "Found --no-permissions flag. Will skip permission updates."
+    break
+  fi
+done
+
+# --- Main Execution ---
 CONFIG=$MACHINE-$COMPILER
 LOG_FILE=$CONFIG.log
 
 echo "Building the TPLs on $MACHINE for $COMPILER to be installed at $INSTALL_DIR. Progress will be written to $LOG_FILE."
 
-ssh $MACHINE -t "
-. /etc/profile  &&
-cd $PWD &&
-$GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix ${INSTALL_DIR}/${CONFIG}_tpls --spack-env-name ${CONFIG}_env &&
-exit" > $LOG_FILE 2>&1
+# Note: The ssh command forwards the extra arguments ($@) to uberenv.py
+ssh "$MACHINE" -t "
+. /etc/profile &&
+cd \"$PWD\" &&
+$GET_A_NODE ./scripts/uberenv/uberenv.py --spec ${SPEC} --prefix \"${INSTALL_DIR}/${CONFIG}_tpls\" --spack-env-name \"${CONFIG}_env\" \"$@\" &&
+exit" > "$LOG_FILE" 2>&1
 
 ## Check the last ten lines of the log file.
 ## A successful install should show up on one of the final lines.
-tail -10 $LOG_FILE | grep -E "Successfully installed geos" > /dev/null
+tail -10 "$LOG_FILE" | grep -E "Successfully installed geos" > /dev/null
 if [ $? -eq 0 ]; then
-    echo "Cleanup extra build files at ${INSTALL_DIR}/${CONFIG}_tpls/ ."
-    rm -rf ${INSTALL_DIR}/${CONFIG}_tpls/${CONFIG}_env
-    rm -rf ${INSTALL_DIR}/${CONFIG}_tpls/.spack-db
-    rm -rf ${INSTALL_DIR}/${CONFIG}_tpls/misc_cache
-    rm -rf ${INSTALL_DIR}/${CONFIG}_tpls/spack
-    rm -rf ${INSTALL_DIR}/${CONFIG}_tpls/build_stage
+  echo "Cleanup extra build files at ${INSTALL_DIR}/${CONFIG}_tpls/."
+  rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/${CONFIG}_env"
+  rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/.spack-db"
+  rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/misc_cache"
+  rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/spack"
+  rm -rf "${INSTALL_DIR}/${CONFIG}_tpls/build_stage"
 
-    echo "Updating file permissions at ${INSTALL_DIR}/${CONFIG}_tpls/ ."
+  # --- 3. Conditionally Set Permissions ---
+  if [ "$SET_PERMISSIONS" = true ]; then
+    echo "Updating file permissions at ${INSTALL_DIR}/${CONFIG}_tpls/."
     # Install directory root
-    chmod g+rx $INSTALL_DIR
-    chgrp GEOS $INSTALL_DIR
+    chmod g+rx "$INSTALL_DIR"
+    chgrp GEOS "$INSTALL_DIR"
 
     # Update only executable and library directories to avoid NFS errors
-    chmod g+rx -R $INSTALL_DIR/${CONFIG}_tpls/bin
-    chgrp GEOS -R $INSTALL_DIR/${CONFIG}_tpls/bin
-    chmod g+rx -R $INSTALL_DIR/${CONFIG}_tpls/${COMPILER%%-*}*
-    chgrp GEOS -R $INSTALL_DIR/${CONFIG}_tpls/${COMPILER%%-*}*
+    chmod g+rx -R "${INSTALL_DIR}/${CONFIG}_tpls/bin"
+    chgrp GEOS -R "${INSTALL_DIR}/${CONFIG}_tpls/bin"
+    chmod g+rx -R "${INSTALL_DIR}/${CONFIG}_tpls/${COMPILER%%-*}"*
+    chgrp GEOS -R "${INSTALL_DIR}/${CONFIG}_tpls/${COMPILER%%-*}"*
+  else
+    echo "Skipping permission updates as requested."
+  fi
 
-    echo "Build of ${CONFIG} completed successfully."
-    exit 0
+  echo "Build of ${CONFIG} completed successfully."
+  exit 0
 else
-    echo "Build of ${CONFIG} seemed to fail, check $LOG_FILE."
-    exit 1
+  echo "Build of ${CONFIG} seemed to fail, check $LOG_FILE."
+  exit 1
 fi

--- a/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
@@ -41,8 +41,8 @@ spack:
         all: '{compiler.name}-{compiler.version}/{name}-{version}-{hash}'
     misc_cache: $spack/../misc_cache
     test_stage: $spack/../test_stage
-    build_stage::
-    - $spack/../build_stage
+    build_stage: $spack/../build_stage
+    build_jobs: 112
 
   # Regular TPLs do not need views
   view: false
@@ -112,7 +112,7 @@ spack:
 
   packages:
     all:
-      target: [ivybridge]
+      target: [sapphirerapids]
 
     mpi:
       require:

--- a/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack_configs/toss_4_x86_64_ib/spack.yaml
@@ -175,6 +175,16 @@ spack:
             fortran: /usr/tce/packages/gcc/gcc-13.3.1-magic/bin/gfortran
           extra_rpaths: []
 
+    gcc-runtime:
+      buildable: False
+      externals:
+      - spec: gcc-runtime@13.3.1
+        prefix: /usr/tce/packages/gcc/gcc-13.3.1/lib/gcc/x86_64-redhat-linux/13
+      - spec: gcc-runtime@12.1.1
+        prefix: /usr/tce/packages/gcc/gcc-12.1.1/lib/gcc/x86_64-redhat-linux/12
+      - spec: gcc-runtime@11.2.1
+        prefix: /usr/tce/packages/gcc/gcc-11.2.1/lib/gcc/x86_64-redhat-linux/11
+
     # Lock down which MPI we are using
     mvapich2:
       buildable: False
@@ -284,4 +294,14 @@ spack:
       buildable: false
       externals:
       - spec: zlib@1.2.11
+        prefix: /usr
+    bison:
+      buildable: false
+      externals:
+      - spec: bison@3.0.4
+        prefix: /usr
+    flex:
+      buildable: false
+      externals:
+      - spec: flex@2.6.1
         prefix: /usr

--- a/scripts/spack_configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack_configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -26,7 +26,7 @@ spack:
     misc_cache: $spack/../misc_cache
     test_stage: $spack/../test_stage
     build_stage: $spack/../build_stage
-    build_jobs: 48
+    build_jobs: 96
 
   # Regular TPLs do not need views
   view: false

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -661,9 +661,9 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             # Lassen
             if sys_type in ('blueos_3_ppc64le_ib_p9'):
                 cfg.write(cmake_cache_string('ATS_ARGUMENTS', '--ats jsrun_omp --ats jsrun_bind=packed'))
-            # Ruby
+            # Dane/Matrix
             if sys_type in ('toss_4_x86_64_ib'):
-                cfg.write(cmake_cache_string('ATS_ARGUMENTS', '--machine slurm56'))
+                cfg.write(cmake_cache_string('ATS_ARGUMENTS', '--machine slurm112'))
 
     def lvarray_hostconfig(self, spec, prefix, py_site_pkgs_dir=None):
         """


### PR DESCRIPTION
- Add `--no-permissions` flag to build scripts so we can run them without the admin account
- Fix compiler order in the machine specs according to spack v1
- Bump up `build_jobs` for matrix and tuo
- Fix matrix arch
- Fix ATS flags for Dane and Matrix
- Add `bison`, `flex`, and `gcc-runtime` to `toss_4_x86_64_ib`