### PR TITLE
Update TPLs

### DIFF
--- a/.github/workflows/docker_build_tpls.yml
+++ b/.github/workflows/docker_build_tpls.yml
@@ -93,6 +93,15 @@ jobs:
     - name: Print environment
       run: printenv
 
+    - name: Inject CA certificate into Docker build
+      if: matrix.RUNS_ON == 'streak2'
+      run: |
+        # 1. Copy the host's CA bundle into the Docker build context
+        cp /etc/pki/tls/certs/ca-bundle.crt ./ca-bundle.crt
+
+        # 2. Inject the COPY and update-ca-trust commands right before dnf runs
+        sed -i '/RUN dnf clean all/i COPY ca-bundle.crt /etc/pki/ca-trust/source/anchors/ca-bundle.crt\nRUN update-ca-trust extract' ${{ matrix.TPL_DOCKERFILE }}
+
     - name: Run the docker build docker script
       env:
         TPL_DOCKERFILE: ${{ matrix.TPL_DOCKERFILE }}

--- a/.github/workflows/docker_build_tpls.yml
+++ b/.github/workflows/docker_build_tpls.yml
@@ -56,11 +56,15 @@ jobs:
           - name: Rockylinux (8, gcc 13.3, cuda 12.9.1)
             DOCKER_REPOSITORY: geosx/rockylinux8-gcc13-cuda12.9.1
             TPL_DOCKERFILE: docker/tpl-rockylinux-gcc-cuda-12.Dockerfile
-            RUNS_ON: Runner_4core_16GB
+            RUNS_ON: streak2
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all -v /etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro -v /etc/pki/tls/certs/ca-bundle.crt:/certs/ca-bundle.crt:ro"
           - name: Rockylinux (8, clang 17.0.6, cuda 12.9.1)
             DOCKER_REPOSITORY: geosx/rockylinux8-clang17-cuda12.9.1
             TPL_DOCKERFILE: docker/tpl-rockylinux-clang-cuda-12.Dockerfile
-            RUNS_ON: Runner_4core_16GB
+            RUNS_ON: streak2
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all -v /etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro -v /etc/pki/tls/certs/ca-bundle.crt:/certs/ca-bundle.crt:ro"
           # - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, zlib 1.2.11)
           #   DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
           #   TPL_DOCKERFILE: docker/Stanford/Dockerfile

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -6,8 +6,8 @@
 "spack_configs_path": "scripts/spack_configs",
 "spack_packages_path": "scripts/spack_packages/packages",
 "spack_url": "https://github.com/spack/spack",
-"spack_commit": "0c2be44e4ece21eb091ad5de4c97716b7c6d4c87",
-"spack_commit_note": "v1.1.0 (Nov 14th 2025)",
+"spack_commit": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
+"spack_commit_note": "v1.1.1 (Jan 14th 2026)",
 "spack_packages_commit": "3dd98680871078353a28ee508fa76c7554f918fa",
 "spack_packages_note": "Feb 25th 2026"
 }

--- a/.uberenv_config.json
+++ b/.uberenv_config.json
@@ -8,6 +8,6 @@
 "spack_url": "https://github.com/spack/spack",
 "spack_commit": "0c2be44e4ece21eb091ad5de4c97716b7c6d4c87",
 "spack_commit_note": "v1.1.0 (Nov 14th 2025)",
-"spack_packages_commit": "cfa8d650480c409de2d568cf1355bf7e509f4c1c",
-"spack_packages_note": "Jan 21st 2026"
+"spack_packages_commit": "3dd98680871078353a28ee508fa76c7554f918fa",
+"spack_packages_note": "Feb 25th 2026"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ list(APPEND build_list raja )
 # CHAI
 ################################
 set(CHAI_DIR "${CMAKE_INSTALL_PREFIX}/chai")
-set(CHAI_URL "${TPL_MIRROR_DIR}/chai-2025.03.0.tar.gz")
+set(CHAI_URL "${TPL_MIRROR_DIR}/chai-2025.12.0.tar.gz")
 message(STATUS "Building CHAI found at ${CHAI_URL}")
 
 ExternalProject_Add( chai

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,7 +448,7 @@ if (ENABLE_CALIPER)
 
 
     set(CALIPER_DIR "${CMAKE_INSTALL_PREFIX}/caliper")
-    set(CALIPER_URL "${TPL_MIRROR_DIR}/Caliper-2.12.0.tar.gz")
+    set(CALIPER_URL "${TPL_MIRROR_DIR}/Caliper-2.14.0.tar.gz")
     message(STATUS "Building Caliper found at ${CALIPER_URL}")
 
     set(CALIPER_WITH_CUPTI OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,7 @@ list(APPEND build_list silo )
 
 
 set(RAJA_DIR "${CMAKE_INSTALL_PREFIX}/raja")
-set(RAJA_URL "${TPL_MIRROR_DIR}/RAJA-v2025.03.0.tar.gz")
+set(RAJA_URL "${TPL_MIRROR_DIR}/RAJA-v2025.12.0.tar.gz")
 
 
 message(STATUS "Building RAJA found at ${RAJA_URL}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set( ENABLE_DOXYGEN OFF CACHE BOOL "" FORCE )
 ################################
 # BLT
 ################################
+set( CXX_STANDARD 17 )
 set( BLT_CXX_STD c++17 CACHE STRING "" FORCE )
 
 if (DEFINED BLT_SOURCE_DIR)
@@ -235,7 +236,7 @@ list(APPEND build_list hdf5 )
 # Conduit
 ################################
 set(CONDUIT_DIR "${CMAKE_INSTALL_PREFIX}/conduit")
-set(CONDUIT_URL "${TPL_MIRROR_DIR}/conduit-0.9.2.tar.gz")
+set(CONDUIT_URL "${TPL_MIRROR_DIR}/conduit-v0.9.5-src-with-blt.tar.gz")
 message(STATUS "Building Conduit found at ${CONDUIT_URL}")
 
 if( ${ENABLE_MPI} )
@@ -282,7 +283,7 @@ ExternalProject_Add( conduit
                                 -D CMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
                                 -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                                 -D CMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
-                                -D BLT_CXX_STD:STRING=c++14
+                                -D BLT_CXX_STD:STRING=${BLT_CXX_STD}
                                 )
 
 list(APPEND build_list conduit )
@@ -1204,7 +1205,7 @@ ExternalProject_Add( fmt
                                 -D CMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
                                 -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS}
                                 -D CMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
-                                -D CMAKE_CXX_STANDARD=14
+                                -D CMAKE_CXX_STANDARD=${CXX_STANDARD}
                                 -D CMAKE_CXX_VISIBILITY_PRESET:STRING=default
                                 -D CMAKE_VISIBILITY_INLINES_HIDDEN:BOOL=OFF
                                 -D FMT_TEST:BOOL=OFF )

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -105,8 +105,8 @@ function launch_jobs() {
 
     tuo|tuolumne)
       ALLOC_CMD="srun -N 1 --exclusive -t 60 -A vortex"
-      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne cce-20-rocm-6.4.2             "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%cce-20 ${COMMON}" "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne llvm-amdgpu-6.4.2-rocm-6.4.2  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%llvm-amdgpu_6_4_2 ${COMMON}" "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne cce-20-rocm-6.4.3  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%cce-20 ${COMMON}" "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne llvm-amdgpu-6.4.3  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%llvm-amdgpu_6_4_3 ${COMMON}" "${ALLOC_CMD}" "$@" &
       ;;
 
     *)

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -89,24 +89,24 @@ function launch_jobs() {
   case "$machine" in
     dane)
       ALLOC_CMD="srun -N 1 --exclusive -t 60 -A vortex"
-      "${UBERENV_HELPER}" "$INSTALL_DIR" dane gcc-12                 "+docs %gcc-12 ${COMMON}"        "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" dane gcc-13                 "+docs %gcc-13 ${COMMON}"        "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" dane llvm-14               "+docs %clang-14 ${COMMON}"      "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" dane llvm-19               "+docs %clang-19 ${COMMON}"      "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" dane gcc-12  "+docs %%gcc-12 ${COMMON}"   "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" dane gcc-13  "+docs %%gcc-13 ${COMMON}"   "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" dane llvm-14 "+docs %%clang-14 ${COMMON}" "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" dane llvm-19 "+docs %%clang-19 ${COMMON}" "${ALLOC_CMD}" "$@" &
       ;;
 
     matrix)
       ALLOC_CMD="srun -N 1 --exclusive -t 60 -A vortex"
-      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix gcc-12-cuda-12.6     "+cuda~uncrustify cuda_arch=90 %gcc-12 ^cuda@12.6.0+allow-unsupported-compilers ${COMMON}"   "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix gcc-13-cuda-12.9     "+cuda~uncrustify cuda_arch=90 %gcc-13 ^cuda@12.9.1+allow-unsupported-compilers ${COMMON}"   "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix llvm-14-cuda-12.6   "+cuda~uncrustify cuda_arch=90 %clang-14 ^cuda@12.6.0+allow-unsupported-compilers ${COMMON}" "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix llvm-19-cuda-12.9   "+cuda~uncrustify cuda_arch=90 %clang-19 ^cuda@12.9.1+allow-unsupported-compilers ${COMMON}" "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix gcc-12-cuda-12.6  "+cuda~uncrustify cuda_arch=90 %%gcc-12 ^cuda@12.6.0+allow-unsupported-compilers ${COMMON}"   "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix gcc-13-cuda-12.9  "+cuda~uncrustify cuda_arch=90 %%gcc-13 ^cuda@12.9.1+allow-unsupported-compilers ${COMMON}"   "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix llvm-14-cuda-12.6 "+cuda~uncrustify cuda_arch=90 %%clang-14 ^cuda@12.6.0+allow-unsupported-compilers ${COMMON}" "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" matrix llvm-19-cuda-12.9 "+cuda~uncrustify cuda_arch=90 %%clang-19 ^cuda@12.9.1+allow-unsupported-compilers ${COMMON}" "${ALLOC_CMD}" "$@" &
       ;;
 
     tuo|tuolumne)
       ALLOC_CMD="srun -N 1 --exclusive -t 60 -A vortex"
-      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne cce-20-rocm-6.4.2  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %cce-20 ${COMMON}" "${ALLOC_CMD}" "$@" &
-      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne llvm-amdgpu-6.4.2-rocm-6.4.2  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %llvm-amdgpu_6_4_2 ${COMMON}" "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne cce-20-rocm-6.4.2             "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%cce-20 ${COMMON}" "${ALLOC_CMD}" "$@" &
+      "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne llvm-amdgpu-6.4.2-rocm-6.4.2  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%llvm-amdgpu_6_4_2 ${COMMON}" "${ALLOC_CMD}" "$@" &
       ;;
 
     *)

--- a/scripts/setupLC-TPL-uberenv.bash
+++ b/scripts/setupLC-TPL-uberenv.bash
@@ -85,10 +85,10 @@ function launch_jobs() {
 
   echo "-----> Launching jobs for [${machine}]..."
 
-  # Note: The max. time allowed on the debug queue is 1h. If we need more, switch to pbatch
+  # Note: The max time allowed on the debug queue is 1h. If we need more, switch to pbatch
   case "$machine" in
     dane)
-      ALLOC_CMD="srun -N 1 --exclusive -t 60 -A vortex"
+      ALLOC_CMD="salloc -N 1 --exclusive -p pdebug -t 60 -A vortex"
       "${UBERENV_HELPER}" "$INSTALL_DIR" dane gcc-12  "+docs %%gcc-12 ${COMMON}"   "${ALLOC_CMD}" "$@" &
       "${UBERENV_HELPER}" "$INSTALL_DIR" dane gcc-13  "+docs %%gcc-13 ${COMMON}"   "${ALLOC_CMD}" "$@" &
       "${UBERENV_HELPER}" "$INSTALL_DIR" dane llvm-14 "+docs %%clang-14 ${COMMON}" "${ALLOC_CMD}" "$@" &
@@ -96,7 +96,7 @@ function launch_jobs() {
       ;;
 
     matrix)
-      ALLOC_CMD="srun -N 1 --exclusive -t 60 -A vortex"
+      ALLOC_CMD="salloc -N 1 --exclusive -p pdebug -t 60 -A vortex"
       "${UBERENV_HELPER}" "$INSTALL_DIR" matrix gcc-12-cuda-12.6  "+cuda~uncrustify cuda_arch=90 %%gcc-12 ^cuda@12.6.0+allow-unsupported-compilers ${COMMON}"   "${ALLOC_CMD}" "$@" &
       "${UBERENV_HELPER}" "$INSTALL_DIR" matrix gcc-13-cuda-12.9  "+cuda~uncrustify cuda_arch=90 %%gcc-13 ^cuda@12.9.1+allow-unsupported-compilers ${COMMON}"   "${ALLOC_CMD}" "$@" &
       "${UBERENV_HELPER}" "$INSTALL_DIR" matrix llvm-14-cuda-12.6 "+cuda~uncrustify cuda_arch=90 %%clang-14 ^cuda@12.6.0+allow-unsupported-compilers ${COMMON}" "${ALLOC_CMD}" "$@" &
@@ -104,7 +104,7 @@ function launch_jobs() {
       ;;
 
     tuo|tuolumne)
-      ALLOC_CMD="srun -N 1 --exclusive -t 60 -A vortex"
+      ALLOC_CMD="salloc -N 1 --exclusive -p pdebug -t 60 -A vortex"
       "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne cce-20-rocm-6.4.3  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%cce-20 ${COMMON}" "${ALLOC_CMD}" "$@" &
       "${UBERENV_HELPER}" "$INSTALL_DIR" tuolumne llvm-amdgpu-6.4.3  "+rocm~pygeosx~trilinos~petsc~docs amdgpu_target=gfx942 %%llvm-amdgpu_6_4_3 ${COMMON}" "${ALLOC_CMD}" "$@" &
       ;;

--- a/scripts/spack_configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack_configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -142,11 +142,9 @@ spack:
       buildable: false
       externals:
       - spec: cray-mpich@9.0.1_cce %cce@20.0.0
-        # prefix: /usr/tce/packages/cray-mpich/cray-mpich-9.0.1-cce-20.0.0-magic
-        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-9.0.1-rocmcc-6.4.3-cce-20.0.0/
+        prefix: /opt/cray/pe/mpich/9.0.1/ofi/cray/20.0
       - spec: cray-mpich@9.0.1_llvm_amdgpu %llvm-amdgpu@6.4.3
-        # prefix: /usr/tce/packages/cray-mpich/cray-mpich-9.0.1-rocmcc-6.4.3-cce-20.0.0-magic
-        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-9.0.1-rocmcc-6.4.3/
+        prefix: /opt/cray/pe/mpich/9.0.1/ofi/amd/6.0
 
     # ROCm packages
     hip:

--- a/scripts/spack_configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack_configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -10,14 +10,16 @@
 # See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
 #------------------------------------------------------------------------------------------------------------
 
-# geosx@develop%cce@20.0.0
-# geosx@develop%llvm-amdgpu_6_4_2
+# geosx@develop %%cce@20.0.0
+# geosx@develop %%llvm-amdgpu_6_4_3
 #
 # Uberenv command to build geos dependencies:
-# python3 ./scripts/uberenv/uberenv.py --spec="+rocm~pygeosx+hypre~trilinos~petsc~docs amdgpu_target=gfx942 %cce-20 ^vtk generator=ninja"
+# python3 ./scripts/uberenv/uberenv.py --spec="+rocm~pygeosx+hypre~trilinos~petsc~docs amdgpu_target=gfx942 %%cce-20 ^vtk generator=ninja"
 #
-# python3 ./scripts/uberenv/uberenv.py --spec="+rocm~pygeosx+hypre~trilinos~petsc~docs amdgpu_target=gfx942 %llvm-amdgpu_6_4_2 ^vtk generator=ninja"
-
+# python3 ./scripts/uberenv/uberenv.py --spec="+rocm~pygeosx+hypre~trilinos~petsc~docs amdgpu_target=gfx942 %%llvm-amdgpu_6_4_3 ^vtk generator=ninja"
+#
+# NOTE: Use "%%" to propagate the compiler choice to dependency libraries
+#
 
 spack:
   config:
@@ -39,12 +41,12 @@ spack:
   - ../versions.yaml
 
   toolchains:
-    llvm-amdgpu_6_4_2:
-    - spec: '%c=llvm-amdgpu@6.4.2'
+    llvm-amdgpu_6_4_3:
+    - spec: '%c=llvm-amdgpu@6.4.3'
       when: '%c'
-    - spec: '%cxx=llvm-amdgpu@6.4.2'
+    - spec: '%cxx=llvm-amdgpu@6.4.3'
       when: '%cxx'
-    - spec: '%fortran=llvm-amdgpu@6.4.2'
+    - spec: '%fortran=llvm-amdgpu@6.4.3'
       when: '%fortran'
     - spec: '%cray-mpich@9.0.1_llvm_amdgpu'
       when: '%mpi'
@@ -102,25 +104,25 @@ spack:
 
     llvm-amdgpu:
       externals:
-      - spec: llvm-amdgpu@=6.4.2
-        prefix: /opt/rocm-6.4.2/llvm
+      - spec: llvm-amdgpu@=6.4.3
+        prefix: /opt/rocm-6.4.3/llvm
         extra_attributes:
           compilers:
-            c: /opt/rocm-6.4.2/llvm/bin/amdclang
-            cxx: /opt/rocm-6.4.2/llvm/bin/amdclang++
-            fortran: /opt/rocm-6.4.2/llvm/bin/amdflang
+            c: /opt/rocm-6.4.3/llvm/bin/amdclang
+            cxx: /opt/rocm-6.4.3/llvm/bin/amdclang++
+            fortran: /opt/rocm-6.4.3/llvm/bin/amdflang
           flags: {}
           environment:
             set: # Needed for scotch
               BISON: bison
               FLEX: flex
           extra_rpaths:
-          - /opt/rocm-6.4.2/lib
-          - /opt/rocm-6.4.2/llvm/lib
+          - /opt/rocm-6.4.3/lib
+          - /opt/rocm-6.4.3/llvm/lib
           - /opt/cray/pe/mpich/9.0.1/ofi/crayclang/20.0/lib
           - /opt/cray/pe/mpich/9.0.1/gtl/lib
         modules:
-        - rocm/6.4.2
+        - rocm/6.4.3
         - PrgEnv-cray/8.6.0
         - craype-x86-genoa
         - craype/2.7.35
@@ -141,132 +143,192 @@ spack:
       externals:
       - spec: cray-mpich@9.0.1_cce %cce@20.0.0
         # prefix: /usr/tce/packages/cray-mpich/cray-mpich-9.0.1-cce-20.0.0-magic
-        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-9.0.1-rocmcc-6.4.2-cce-20.0.0/
-      - spec: cray-mpich@9.0.1_llvm_amdgpu %llvm-amdgpu@6.4.2
-        # prefix: /usr/tce/packages/cray-mpich/cray-mpich-9.0.1-rocmcc-6.4.2-cce-20.0.0-magic
-        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-9.0.1-rocmcc-6.4.2/
+        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-9.0.1-rocmcc-6.4.3-cce-20.0.0/
+      - spec: cray-mpich@9.0.1_llvm_amdgpu %llvm-amdgpu@6.4.3
+        # prefix: /usr/tce/packages/cray-mpich/cray-mpich-9.0.1-rocmcc-6.4.3-cce-20.0.0-magic
+        prefix: /usr/tce/packages/cray-mpich-tce/cray-mpich-9.0.1-rocmcc-6.4.3/
 
     # ROCm packages
     hip:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: hip@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: hip@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: hip@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     hipsparse:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: hipsparse@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: hipsparse@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: hipsparse@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     hipblas:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: hipblas@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: hipblas@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: hipblas@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     hipblas-common:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: hipblas-common@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: hipblas-common@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: hipblas-common@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     hipsolver:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: hipsolver@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: hipsolver@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: hipsolver@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     hsa-rocr-dev:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: hsa-rocr-dev@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: hsa-rocr-dev@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: hsa-rocr-dev@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocminfo:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocminfo@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocminfo@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocminfo@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocm-device-libs:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocm-device-libs@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocm-device-libs@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocm-device-libs@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocprim:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocprim@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocprim@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocprim@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocthrust:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocthrust@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocthrust@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocthrust@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocsparse:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocsparse@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocsparse@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocsparse@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocrand:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocrand@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocrand@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocrand@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocblas:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocblas@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocblas@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocblas@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocsolver:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocsolver@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocsolver@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocsolver@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
     rocm-core:
-      version: [6.4.0, 6.4.2]
       buildable: false
       externals:
       - spec: rocm-core@6.4.0
         prefix: /opt/rocm-6.4.0
-      - spec: rocm-core@6.4.2
-        prefix: /opt/rocm-6.4.2
+      - spec: rocm-core@6.4.3
+        prefix: /opt/rocm-6.4.3
+      require:
+      - when: "%llvm-amdgpu@6.4.3"
+        spec: "@6.4.3"
+      - when: "%cce@20.0.0"
+        spec: "@6.4.0"
 
     # System level packages to not build
     python:

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -23,10 +23,6 @@ packages:
     require: "@git.8b0093306228fef1b92384d9face7fbe5a63b460=master"
 
   # v2025.0.3.0
-  chai:
-    require: "@git.4b9060b18b9bec1167026cfb3132bd540c4bd56b=develop"
-
-  # v2025.0.3.0
   umpire:
     require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
 

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -38,10 +38,6 @@ packages:
   camp:
     require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
 
-  # v2.12.0
-  caliper:
-    require: "@git.287b7f3ad2d12f520aad04268d44f353cd05403c"
-
   # v0.9.2
   conduit:
     require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -14,10 +14,6 @@
 # This file lists the package versions for geos's dependencies
 #
 packages:
-  # v0.6.2
-  blt:
-    require: "@git.9ff77344f0b2a6ee345e452bddd6bfd46cbbfa35=develop"
-
   # master - 01/23/26
   hypre:
     require: "@git.8b0093306228fef1b92384d9face7fbe5a63b460=master"

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -22,14 +22,6 @@ packages:
   hypre:
     require: "@git.8b0093306228fef1b92384d9face7fbe5a63b460=master"
 
-  # v2025.0.3.0
-  umpire:
-    require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
-
-  # v2025.0.3.0
-  camp:
-    require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
-
   # v0.9.2
   conduit:
     require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -31,10 +31,6 @@ packages:
     require: "@git.1ed0669c57f041baa1f1070693991c3a7a43e7ee=develop"
 
   # v2025.0.3.0
-  raja:
-    require: "@git.1d70abf171474d331f1409908bdf1b1c3fe19222=develop"
-
-  # v2025.0.3.0
   camp:
     require: "@git.ee0a3069a7ae72da8bcea63c06260fad34901d43=main"
 

--- a/scripts/spack_configs/versions.yaml
+++ b/scripts/spack_configs/versions.yaml
@@ -18,10 +18,6 @@ packages:
   hypre:
     require: "@git.8b0093306228fef1b92384d9face7fbe5a63b460=master"
 
-  # v0.9.2
-  conduit:
-    require: "@git.ad86e316ad56a75c099d30ca5ce75cff275b5924=develop"
-
   # master - 04/12/20
   uncrustify:
     require: "@git.401a4098bce9dcc47e024987403f2d59d9ba7bd2"

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -119,7 +119,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("umpire~openmp", when="~openmp")
     depends_on("umpire+openmp", when="+openmp")
 
-    depends_on('chai +raja~examples~shared')
+    depends_on('chai @2025.12.0 +raja~examples~shared')
     depends_on("chai~openmp", when="~openmp")
     depends_on("chai+openmp", when="+openmp")
 

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -111,7 +111,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     #
     # Performance portability
     #
-    depends_on('raja ~examples~exercises~shared')
+    depends_on('raja @2025.12.0 ~examples~exercises~shared')
     depends_on("raja~openmp", when="~openmp")
     depends_on("raja+openmp", when="+openmp")
 

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -532,7 +532,20 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
 
             for tpl, cmake_name, enable in io_tpls:
                 if enable:
-                    cfg.write(cmake_cache_entry('{}_DIR'.format(cmake_name), spec[tpl].prefix))
+                    dep_spec = None
+                    if tpl == 'zlib':
+                        # Spack may concretize zlib-api to zlib-ng instead of zlib.
+                        for candidate in ('zlib', 'zlib-ng', 'zlib-api'):
+                            try:
+                                dep_spec = spec[candidate]
+                                break
+                            except KeyError:
+                                pass
+                        if dep_spec is None:
+                            raise KeyError("No zlib provider (zlib/zlib-ng/zlib-api) found in {0}".format(spec))
+                    else:
+                        dep_spec = spec[tpl]
+                    cfg.write(cmake_cache_entry('{}_DIR'.format(cmake_name), dep_spec.prefix))
                 else:
                     cfg.write(cmake_cache_option('ENABLE_{}'.format(cmake_name), False))
 

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -181,11 +181,12 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
         depends_on("trilinos+openmp", when="+openmp")
 
     with when("+hypre"):
-        depends_on("hypre +superlu-dist+mixedint+mpi~shared+pic", when='~cuda~rocm')
-        depends_on("hypre +cuda+superlu-dist+mixedint+mpi+umpire+unified-memory~shared+pic", when='+cuda')
-        depends_on("hypre +rocm+superlu-dist+mixedint+mpi+umpire+unified-memory~shared+pic", when='+rocm')
+        depends_on("hypre +superlu-dist+mixedint+mpi", when='~cuda~rocm')
+        depends_on("hypre +cuda+superlu-dist+mixedint+mpi+umpire+unified-memory", when='+cuda')
+        depends_on("hypre +rocm+superlu-dist+mixedint+mpi+umpire+unified-memory", when='+rocm')
         depends_on("hypre ~openmp", when="~openmp")
-        depends_on("hypre +openmp", when="+openmp")
+        depends_on("hypre +pic", when="~shared")
+        depends_on("hypre +shared", when="+shared")
 
     depends_on('petsc@3.19.4~hdf5~hypre+int64', when='+petsc')
     depends_on('petsc+ptscotch', when='+petsc+scotch')

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -144,7 +144,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('hdf5@1.14.6')
     depends_on('silo@4.12.0~fortran~shared~python build_system=cmake')
 
-    depends_on('conduit~test~fortran~hdf5_compat+shared')
+    depends_on('conduit@0.9.5 ~test~fortran~hdf5_compat+shared')
 
     depends_on('adiak@0.4.0 ~shared', when='+caliper')
     depends_on('caliper@2.14.0 ~gotcha~sampler~libunwind~libdw', when='+caliper')

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -99,7 +99,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('cmake@3.24:', type='build')
 
-    depends_on('blt')
+    depends_on('blt@0.7.1')
 
     #
     # Virtual packages

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -76,6 +76,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             multi=False)
     variant('grpc', default=False, description='Enable gRPC.')
     variant('pygeosx', default=True, description='Enable pygeosx.')
+    variant('cxxstd', default='17', description='CXX standard.')
 
     # SPHINX_END_VARIANTS
 
@@ -156,7 +157,9 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on('pugixml@1.13 ~shared')
 
-    depends_on('fmt@10.0.0 cxxstd=14')
+    depends_on('fmt@11')
+    for _fmt_cxxstd in ('14', '17', '20'):
+        depends_on(f'fmt@11 cxxstd={_fmt_cxxstd}', when=f'cxxstd={_fmt_cxxstd}')
     depends_on('vtk@9.4.2', when='+vtk')
 
     #
@@ -355,7 +358,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             cfg.write("# CMake Standard\n")
             cfg.write("#{0}\n\n".format("-" * 80))
 
-            cfg.write(cmake_cache_string("BLT_CXX_STD", "c++17"))
+            cfg.write(cmake_cache_string("BLT_CXX_STD", f"c++{spec.variants['cxxstd'].value}"))
 
             cfg.write("#{0}\n".format("-" * 80))
             cfg.write("# MPI\n")
@@ -439,7 +442,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             cfg.write('#{0}\n\n'.format('-' * 80))
             if '+cuda' in spec:
                 cfg.write(cmake_cache_option('ENABLE_CUDA', True))
-                cfg.write(cmake_cache_entry('CMAKE_CUDA_STANDARD', 17))
+                cfg.write(cmake_cache_string('CMAKE_CUDA_STANDARD', spec.variants['cxxstd'].value))
 
                 cudatoolkitdir = spec['cuda'].prefix
                 cfg.write(cmake_cache_entry('CUDA_TOOLKIT_ROOT_DIR', cudatoolkitdir))
@@ -484,7 +487,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             cfg.write('#{0}\n\n'.format('-' * 80))
             if '+rocm' in spec:
                 cfg.write(cmake_cache_option('ENABLE_HIP', True))
-                cfg.write(cmake_cache_string('CMAKE_HIP_STANDARD', 17))
+                cfg.write(cmake_cache_string('CMAKE_HIP_STANDARD', spec.variants['cxxstd'].value))
                 cfg.write(cmake_cache_entry('CMAKE_HIP_COMPILER', spec['hip'].prefix.bin.hipcc))
 
                 if not spec.satisfies('amdgpu_target=none'):
@@ -767,7 +770,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             cfg.write('#{0}\n\n'.format('-' * 80))
             if '+cuda' in spec:
                 cfg.write(cmake_cache_option('ENABLE_CUDA', True))
-                cfg.write(cmake_cache_entry('CMAKE_CUDA_STANDARD', 17))
+                cfg.write(cmake_cache_string('CMAKE_CUDA_STANDARD', spec.variants['cxxstd'].value))
 
                 cudatoolkitdir = spec['cuda'].prefix
                 cfg.write(cmake_cache_entry('CUDA_TOOLKIT_ROOT_DIR', cudatoolkitdir))

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -163,6 +163,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on("metis +int64~shared cflags='-fPIC' cxxflags='-fPIC'")
 
     depends_on("superlu-dist@9.2.1 +int64 fflags='-fPIC'")
+    depends_on("superlu-dist@9.2.1 +int64 fflags='-fPIC -ef'", when="%cce")
     depends_on("superlu-dist~openmp", when="~openmp")
     depends_on("superlu-dist+openmp", when="+openmp")
 

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -111,20 +111,14 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     #
     # Performance portability
     #
-    depends_on('raja @2025.12.0 ~examples~exercises~shared')
-    depends_on("raja~openmp", when="~openmp")
-    depends_on("raja+openmp", when="+openmp")
-
-    depends_on('umpire +c~examples+fortran~device_alloc~shared')
-    depends_on("umpire~openmp", when="~openmp")
-    depends_on("umpire+openmp", when="+openmp")
-
-    depends_on('chai @2025.12.0 +raja~examples~shared')
-    depends_on("chai~openmp", when="~openmp")
-    depends_on("chai+openmp", when="+openmp")
-
-    depends_on('camp')
-
+    raja_suite_version="2025.12.0"
+    depends_on(f"raja @{raja_suite_version} ~examples~exercises~shared")
+    depends_on(f"chai @{raja_suite_version} +raja~examples~shared")
+    depends_on(f"camp @{raja_suite_version}")
+    depends_on(f"umpire @{raja_suite_version} +c~examples+fortran~device_alloc~shared")
+    with when('+openmp'):
+        for pkg in ('raja', 'chai', 'umpire'):
+            depends_on(f"{pkg}+openmp", when="+openmp")
     #
     # GPUs
     #

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -153,7 +153,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     depends_on('conduit~test~fortran~hdf5_compat+shared')
 
     depends_on('adiak@0.4.0 ~shared', when='+caliper')
-    depends_on('caliper~gotcha~sampler~libunwind~libdw', when='+caliper')
+    depends_on('caliper@2.14.0 ~gotcha~sampler~libunwind~libdw', when='+caliper')
 
     depends_on('pugixml@1.13 ~shared')
 

--- a/tplMirror/Caliper-2.12.0.tar.gz
+++ b/tplMirror/Caliper-2.12.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3e76d64905e4c17676d78047a8e84edbcbe4176edf789850fce42f69a7d9d1e2
-size 2089422

--- a/tplMirror/Caliper-2.14.0.tar.gz
+++ b/tplMirror/Caliper-2.14.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b42c35dfbe485960dd326033893dae37ac00d9807c5c3e6b5b1f396bc4af273f
+size 2093696

--- a/tplMirror/RAJA-v2025.03.0.tar.gz
+++ b/tplMirror/RAJA-v2025.03.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60d047e04e7e7855f7b31e5f54bf66e465c52a6efb3871ace33cc8da1cb1b9ae
-size 11182913

--- a/tplMirror/RAJA-v2025.12.0.tar.gz
+++ b/tplMirror/RAJA-v2025.12.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e8b4656a79fe01f01b122947365537537505073e4a8dbf388ee85f105f678d2
+size 10997567

--- a/tplMirror/chai-2025.03.0.tar.gz
+++ b/tplMirror/chai-2025.03.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:144917f3185b7d112392e9f99c1fbc74b9e0be79cdbee445e0879ea2487d3d73
-size 23937809

--- a/tplMirror/chai-v2025.12.0.tar.gz
+++ b/tplMirror/chai-v2025.12.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c77a17dbb1aade696681b7b747a7437f4e4252361d57dca1fe7edd20d5b1984b
+size 23851995

--- a/tplMirror/conduit-0.9.2.tar.gz
+++ b/tplMirror/conduit-0.9.2.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6a5368bf2232e927db84d14b917c587a82389ca50d5a8e2b1f52bf7764a9f6cb
-size 23576501

--- a/tplMirror/conduit-v0.9.5-src-with-blt.tar.gz
+++ b/tplMirror/conduit-v0.9.5-src-with-blt.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d93294efbf0936da5a27941e13486aa1a04a74a59285786a2303eed19a24265a
+size 109117490


### PR DESCRIPTION
Update spack v1.1.0 (Nov/25) to v1.1.1 (Jan/26)

Update TPLs:
 - BLT v0.6.2 -> v0.7.1
 - Umpire v2025.03.0 -> v2025.12.0
 - CHAI v2025.03.0 -> v2025.12.0
 - RAJA v2025.03.0 -> v2025.12.0
 - Caliper v2.12.0 -> v2.14.0
 - conduit v0.9.2 -> v0.9.5

Moreover:
- Bump spack packages commit to Feb 25th 2026
- Bump rocm version for tuo builds to `rocm 6.4.3`
- Fix build issue with gcc-14 related to C++ standard 
- Fix conduit build issue with llvm-19
- Fix `hypre+shared` build
- Fix github CI runner selection (streak2)
