### PR TITLE
fix version name for chai

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ list(APPEND build_list raja )
 # CHAI
 ################################
 set(CHAI_DIR "${CMAKE_INSTALL_PREFIX}/chai")
-set(CHAI_URL "${TPL_MIRROR_DIR}/chai-2025.12.0.tar.gz")
+set(CHAI_URL "${TPL_MIRROR_DIR}/chai-v2025.12.0.tar.gz")
 message(STATUS "Building CHAI found at ${CHAI_URL}")
 
 ExternalProject_Add( chai


### PR DESCRIPTION
This PR fixes the following compilation issue on Chai version name:

```
[ 25%] Performing download step (verify and extract) for 'chai'
cd /shared/data1/Users/j0551570/Compilation/Develop_260402/thirdPartyLibs/build-pine-CPU-release/chai/src && /hrtc/apps/devtools/spack/PINE/linux-rocky9-zen4/gcc-11.4.1/cmake-3.27.9-7vjtg6qwxhlfws2qt53saqy3jpict2ja/bin/cmake -P /shared/data1/Users/j0551570/Compilation/Develop_260402/thirdPartyLibs/build-pine-CPU-release/chai/src/chai-stamp/verify-chai.cmake
CMake Error at chai-stamp/verify-chai.cmake:11 (message):
  File not found:
  /shared/data1/Users/j0551570/Compilation/Develop_260402/thirdPartyLibs/tplMirror/chai-2025.12.0.tar.gz
```