### PR TITLE
feat: add cpptrace for better stack traces output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1212,6 +1212,64 @@ ExternalProject_Add( fmt
 
 list(APPEND build_list fmt)
 
+################################
+# CPPTRACE
+################################
+
+if( ENABLE_CPPTRACE )
+    set( CPPTRACE_DIR "${CMAKE_INSTALL_PREFIX}/cpptrace" )
+    set( CPPTRACE_URL "${TPL_MIRROR_DIR}/cpptrace-v1.0.0.tar.gz" )
+
+    set( CPPTRACE_SYMBOLS_BACKEND "libbacktrace" CACHE STRING
+         "Symbol resolution back-end for cpptrace (libbacktrace | libdwarf | addr2line)" )
+    set_property( CACHE CPPTRACE_SYMBOLS_BACKEND PROPERTY STRINGS libbacktrace libdwarf addr2line )
+
+    message( STATUS "Building CPPTRACE found at ${CPPTRACE_URL}" )
+    message( STATUS "CPPTRACE_SYMBOLS_BACKEND = ${CPPTRACE_SYMBOLS_BACKEND}" )
+
+    if( CPPTRACE_SYMBOLS_BACKEND STREQUAL "libbacktrace" )
+        set( _cpptrace_backend_args -D CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE:BOOL=ON
+                                    -D CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF:BOOL=OFF
+                                    -D CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE:BOOL=OFF )
+    elseif( CPPTRACE_SYMBOLS_BACKEND STREQUAL "libdwarf" )
+        set( _cpptrace_backend_args -D CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE:BOOL=OFF
+                                    -D CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF:BOOL=ON
+                                    -D CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE:BOOL=OFF
+                                    -D CPPTRACE_USE_EXTERNAL_LIBDWARF:BOOL=ON
+                                    -D CPPTRACE_USE_EXTERNAL_ZSTD:BOOL=ON )
+    elseif( CPPTRACE_SYMBOLS_BACKEND STREQUAL "addr2line" )
+        set( _cpptrace_backend_args -D CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE:BOOL=OFF
+                                    -D CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF:BOOL=OFF
+                                    -D CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE:BOOL=ON )
+    else()
+        message( FATAL_ERROR
+                 "CPPTRACE_SYMBOLS_BACKEND='${CPPTRACE_SYMBOLS_BACKEND}' is not a valid value. "
+                 "Use libbacktrace, libdwarf, or addr2line" )
+    endif()
+
+    ExternalProject_Add( cpptrace
+                         PREFIX ${PROJECT_BINARY_DIR}/cpptrace
+                         URL ${CPPTRACE_URL}
+                         INSTALL_DIR ${CPPTRACE_DIR}
+                         BUILD_COMMAND ${TPL_BUILD_COMMAND}
+                         INSTALL_COMMAND ${TPL_INSTALL_COMMAND}
+                         CMAKE_GENERATOR ${TPL_GENERATOR}
+                         CMAKE_ARGS -D CMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+                                    -D CMAKE_C_COMPILER=${MPI_C_COMPILER}
+                                    -D CMAKE_C_FLAGS=${C_FLAGS_NO_WARNINGS}
+                                    -D CMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE}
+                                    -D CMAKE_CXX_COMPILER=${MPI_CXX_COMPILER}
+                                    -D CMAKE_CXX_FLAGS=${CXX_FLAGS_NO_WARNINGS}
+                                    -D CMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
+                                    -D CMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
+                                    -D CMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+                                    -D BUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} 
+                                    ${_cpptrace_backend_args} )
+
+    list(APPEND build_list cpptrace )
+
+endif( ENABLE_CPPTRACE )
+
 
 ################################
 # Create target that builds all dependencies

--- a/scripts/spack_configs/pangea-4/spack.yaml
+++ b/scripts/spack_configs/pangea-4/spack.yaml
@@ -211,3 +211,11 @@ spack:
       - spec: zlib@1.2.11
         prefix: /usr
       buildable: false
+    zstd:
+      externals:
+      - spec: zstd@1.4.4
+        prefix: /usr
+      buildable: false
+    libdwarf:
+      require: "@0.12.0"
+      buildable: true

--- a/scripts/spack_packages/packages/cpptrace/package.py
+++ b/scripts/spack_packages/packages/cpptrace/package.py
@@ -1,0 +1,40 @@
+# Copyright Spack Project Developers. See COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
+
+from spack.package import *
+
+
+class Cpptrace(CMakePackage):
+    """Simple, portable, and self-contained stacktrace library for C++11 and newer."""
+
+    homepage = "https://github.com/jeremy-rifkin/cpptrace"
+    url = "https://github.com/jeremy-rifkin/cpptrace/archive/refs/tags/v1.0.0.tar.gz"
+
+    maintainers("RMeli")
+
+    license("MIT", checked_by="RMeli")
+
+    version("1.0.0", sha256="0e11aebb6b9b98ce9134a58532b63982365aadc76533a4fbb7f6fb6edb32de2e")
+
+    variant("shared", default=False, description="Build shared libraries")
+    variant("external_libdwarf", default=False, description="Use external libdwarf")
+    variant("external_zstd", default=False, description="Use external zstd")
+
+    generator("ninja")
+
+    depends_on("c", type="build")
+    depends_on("cxx", type="build")
+
+    depends_on("libdwarf", when="+external_libdwarf")
+    depends_on("zstd", when="+external_zstd")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("CPPTRACE_USE_EXTERNAL_LIBDWARF", "external_libdwarf"),
+            self.define_from_variant("CPPTRACE_USE_EXTERNAL_ZSTD", "external_zstd"),
+        ]
+        return args

--- a/scripts/spack_packages/packages/cpptrace/package.py
+++ b/scripts/spack_packages/packages/cpptrace/package.py
@@ -7,6 +7,8 @@ from spack_repo.builtin.build_systems.cmake import CMakePackage, generator
 from spack.package import *
 
 
+# Modified of the Spack package.py version to add cpptrace's backends
+# as variants 
 class Cpptrace(CMakePackage):
     """Simple, portable, and self-contained stacktrace library for C++11 and newer."""
 
@@ -20,21 +22,54 @@ class Cpptrace(CMakePackage):
     version("1.0.0", sha256="0e11aebb6b9b98ce9134a58532b63982365aadc76533a4fbb7f6fb6edb32de2e")
 
     variant("shared", default=False, description="Build shared libraries")
-    variant("external_libdwarf", default=False, description="Use external libdwarf")
-    variant("external_zstd", default=False, description="Use external zstd")
+
+    variant("symbols", 
+            default="libdwarf",
+            values=("libbacktrace", "libdwarf", "addr2line"),
+            multi=False,
+            description="Symbol resolution backend")
+
+    variant("external_libdwarf",
+            default=True,
+            description="Use external libdwarf (only relevant with symbols=libdwarf)")
+
+    variant("external_zstd",
+            default=True, 
+            description="Use external zstd (only relevant with symbols=libdwarf)")
 
     generator("ninja")
 
-    depends_on("c", type="build")
+    depends_on("c",   type="build")
     depends_on("cxx", type="build")
 
-    depends_on("libdwarf", when="+external_libdwarf")
-    depends_on("zstd", when="+external_zstd")
+    depends_on("libdwarf", when="symbols=libdwarf +external_libdwarf")
+    depends_on("zstd",     when="symbols=libdwarf +external_zstd")
 
     def cmake_args(self):
         args = [
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define_from_variant("CPPTRACE_USE_EXTERNAL_LIBDWARF", "external_libdwarf"),
-            self.define_from_variant("CPPTRACE_USE_EXTERNAL_ZSTD", "external_zstd"),
         ]
+
+        backend = self.spec.variants["symbols"].value
+        if backend == "libbacktrace":
+            args += [
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE", True),
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF",     False),
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE",    False),
+            ]
+        elif backend == "libdwarf":
+            args += [
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE", False),
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF",     True),
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE",    False),
+                self.define_from_variant("CPPTRACE_USE_EXTERNAL_LIBDWARF", "external_libdwarf"),
+                self.define_from_variant("CPPTRACE_USE_EXTERNAL_ZSTD", "external_zstd"),
+            ]
+        elif backend == "addr2line":
+            args += [
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_LIBBACKTRACE", False),
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF",     False),
+                self.define("CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE",    True),
+            ]
+
         return args

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -656,6 +656,9 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             if '+cpptrace' in spec:
                 cfg.write(cmake_cache_option('ENABLE_CPPTRACE', True))
                 cfg.write(cmake_cache_entry('CPPTRACE_DIR', spec['cpptrace'].prefix))
+                if spec['cpptrace'].satisfies('symbols=libdwarf'):
+                    cfg.write(cmake_cache_entry('ZSTD_DIR', spec['zstd'].prefix))
+                    cfg.write(cmake_cache_entry('LIBDWARF_DIR', spec['libdwarf'].prefix))
             else:
                 cfg.write(cmake_cache_option('ENABLE_CPPTRACE', False))
 

--- a/scripts/spack_packages/packages/geosx/package.py
+++ b/scripts/spack_packages/packages/geosx/package.py
@@ -89,6 +89,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     variant('addr2line', default=True,
             description='Add support for addr2line.')
     variant('mathpresso', default=True, description='Build mathpresso.')
+    variant('cpptrace', default=False, description='Build cpptrace support.')
 
     variant('cuda_stack_size', default="0", description="Defines the adjusted cuda stack \
         size limit if required. Zero or negative keep default behavior")
@@ -207,6 +208,7 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
     # Dev tools
     #
     depends_on('uncrustify', when='+uncrustify')
+    depends_on('cpptrace', when='+cpptrace')
 
     #
     # Documentation
@@ -650,6 +652,12 @@ class Geosx(CMakePackage, CudaPackage, ROCmPackage):
             if '+uncrustify' in spec:
                 cfg.write(
                     cmake_cache_entry('UNCRUSTIFY_EXECUTABLE', os.path.join(spec['uncrustify'].prefix.bin, 'uncrustify')))
+            
+            if '+cpptrace' in spec:
+                cfg.write(cmake_cache_option('ENABLE_CPPTRACE', True))
+                cfg.write(cmake_cache_entry('CPPTRACE_DIR', spec['cpptrace'].prefix))
+            else:
+                cfg.write(cmake_cache_option('ENABLE_CPPTRACE', False))
 
             if '+addr2line' in spec:
                 cfg.write('#{0}\n'.format('-' * 80))

--- a/tplMirror/cpptrace-v1.0.0.tar.gz
+++ b/tplMirror/cpptrace-v1.0.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e11aebb6b9b98ce9134a58532b63982365aadc76533a4fbb7f6fb6edb32de2e
+size 489294


### PR DESCRIPTION
This PR adds **cpptrace** as a new third party library to have more powerful stack traces outputs from thrown exceptions in GEOS.

The main benefit of this library is the output of the **complete** unwinding, even in STL, of errors (addressed [partially](https://github.com/jeremy-rifkin/cpptrace#what-about-c23-stacktrace) with `<stacktrace>` from C++23)

Both methods, with uberenv/Spack and the older `scripts/config-build.py`, are supported.

On top of that, an option has been added to select the desired backend used by cpptrace to gather symbols (between libdwarf, libbacktrace and addr2line).

Via uberenv/Spack:
```sh
./scripts/uberenv/uberenv.py --spec "+cpptrace ^cpptrace symbols=libdwarf" ... # or libbacktrace, or addr2line
```

Via `scripts/config-build.py`:
as a command-line argument:
```sh
python scripts/config-build.py \
	-hc ../GEOS/host-configs/your-platform.cmake \
	-bt Release \
	-DENABLE_CPPTRACE=ON \
	-DCPPTRACE_SYMBOLS_BACKEND=libbacktrace # or without this line to use the default backend
```
or directly in the host-config:
```cmake
set(ENABLE_CPPTRACE ON CACHE BOOL "")
set(CPPTRACE_SYMBOLS_BACKEND libbacktrace CACHE STRING "") # or without this line to use the default backend
```

More info on symbols backends: https://github.com/jeremy-rifkin/cpptrace#library-back-ends